### PR TITLE
Use unbound regridding method for dask wrapping

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,6 +24,11 @@ New features
   `conservative_normed` to properly handle normalization (:pull:`1`).
   By `Raphael Dussin <https://github.com/raphaeldussin>`_
 
+Bug fixes
+~~~~~~~~~
+* Fix serialization bug when using dask's distributed scheduler (:pull:`39`).
+  By `Pascal Bourgault <https://github.com/aulemahal>`_.
+
 
 
 0.3.0 (06-03-2020)


### PR DESCRIPTION
This fixes JiaweiZhuang/xESMF#71 and #38.

There are currently no tests in the test suite that use distributed dask client, so all I can say is that solved the problem on my machine with dask 2.17. 

From what I understand the problem of using a distributed client is that it must serialize everything it sends to its workers. In the `Regridder` object, we keep the ESMpy Grid/Mesh/Locstream objects, which are not serializable by dask. Thus the error and the workaround that dumped overwrote `_grid_in` and `_grid_out` to `None` (see  JiaweiZhuang/xESMF#71).  I figured out that those two objects were passed to dask only because we were wrapping `Regridder.regrid_numpy` which is a _bound_ method, meaning the whole `Regridder` instance has to passed together with the function to the workers.

This PR creates the `Regridder._regrid_array` _static_ method and passes the needed arguments through a dictionary that removes any internal reference to the instance.