### PR TITLE
Retrieve package version at runtime

### DIFF
--- a/xesmf/__init__.py
+++ b/xesmf/__init__.py
@@ -1,4 +1,11 @@
-__version__='0.4.0'
+# flake8: noqa
+from pkg_resources import DistributionNotFound, get_distribution
 from . import util
 from . import data
 from . frontend import Regridder
+
+try:
+    __version__ = get_distribution(__name__).version
+except DistributionNotFound:  # pragma: no cover
+    __version__ = '0.0.0'  # pragma: no cover
+


### PR DESCRIPTION
Fixes https://github.com/pangeo-data/xESMF/issues/32

Currently, we are using [setuptools-scm](https://github.com/pypa/setuptools_scm/) for managing the package version:

https://github.com/pangeo-data/xESMF/blob/80fdfd40edf9255b6639f82b9ac9dd03318e4919/setup.py#L11-L12

However, the version information was being hard-coded in `__init__.py`. This PR removes the hard-coded version information, and dynamically retrieves the package version via `pkg_resources`. 


P.S.: With `setuptools-scm`, the version information is retrieved from the git tags/commits. So, when it comes to releases, we don't need to bump `__version__` in the package. The only requirement is to publish a release on GitHub and the version information will be propagated by `setuptools-scm`.