### PR TITLE
Fix 34

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -70,32 +70,22 @@ Contents
 How to ask for help
 -------------------
 
-The `GitHub issue tracker <https://github.com/JiaweiZhuang/xESMF/issues>`_ is the primary place for bug reports. If you hit any issues, I recommend the following steps:
+The `GitHub issue tracker <https://github.com/pangeo-data/xESMF/issues>`_ is the primary place for bug reports. If you hit any issues, I recommend the following steps:
 
-- First, `search for existing issues <https://help.github.com/en/articles/searching-issues-and-pull-requests>`_. Other people are likely to hit the same problem and probably have already found the solution.
+- First, `search for existing issues <https://help.github.com/en/articles/searching-issues-and-pull-requests>`_. Other people are likely to hit the same problem and probably have already found the solution. You might also want to search issues in the original repository `<https://github.com/JiaweiZhuang/xESMF/issues>`_.
 
 - For a new bug, please `craft a minimal bug report <https://matthewrocklin.com/blog/work/2018/02/28/minimal-bug-reports>`_ with reproducible code. Use synthetic data or `upload <https://help.github.com/en/articles/file-attachments-on-issues-and-pull-requests>`_ a small sample of input data (~1 MB) so I can quickly reproducible your error.
 
-- For platform-dependent problems (such as kernel dying and installation error), please also show how to reproduce your system environment, otherwise I have no way to diagnose the issue. The best approach is probably finding an `official Docker image <https://docs.docker.com/docker-hub/official_images/>`_ that is closest to your OS (such as `Ubuntu <https://hub.docker.com/_/ubuntu/>`_ or `CentOS <https://hub.docker.com/_/centos/>`_), and build your Python environment starting with such image, to see whether the error still exists. Alternatively you can select from public cloud images, such as `Amazon Machine Images <https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/AMIs.html>`_ or `Google Cloud Images <https://cloud.google.com/compute/docs/images>`_. If the error only happens on your institution's HPC cluster, please contact the system administrator for help.
+- For platform-dependent problems (such as kernel dying and installation error), please also show how to reproduce your system environment, otherwise we have no way to diagnose the issue. The best approach is probably finding an `official Docker image <https://docs.docker.com/docker-hub/official_images/>`_ that is closest to your OS (such as `Ubuntu <https://hub.docker.com/_/ubuntu/>`_ or `CentOS <https://hub.docker.com/_/centos/>`_), and build your Python environment starting with such image, to see whether the error still exists. Alternatively you can select from public cloud images, such as `Amazon Machine Images <https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/AMIs.html>`_ or `Google Cloud Images <https://cloud.google.com/compute/docs/images>`_. If the error only happens on your institution's HPC cluster, please contact the system administrator for help.
 
-For general "how-to" questions that are not bugs, you can also post on `StackOverflow <https://stackoverflow.com/>`_ (ref: `xarray questions <https://stackoverflow.com/questions/tagged/python-xarray>`_) and send me the link. For small questions also feel free to @ me `on Twitter <https://twitter.com/Jiawei_Zhuang_>`_.
-
-
-**The "Don'ts"**:
-
-- Do not describe your problem in a private email, as this would require me to reply similar emails many times. `Keep all discussions in public places <https://matthewrocklin.com/blog/2019/02/28/slack-github>`_ like GitHub or StackOverflow.
-- Do not only show the error/problem without providing the steps to reproduce it.
-- Do not take screenshots of your code, as they are not copy-pastable.
+For general "how-to" questions that are not bugs, you can also post on `StackOverflow <https://stackoverflow.com/>`_ (ref: `xarray questions <https://stackoverflow.com/questions/tagged/python-xarray>`_).
 
 
 How to support xESMF
 --------------------
+Your support in any form will be appreciated. The easy ways (takes several seconds):
 
-xESMF is so far my personal unfunded project; most development happens during my (very limited) free time at graduate school. Your support in any form will be appreciated.
-
-The easy ways (takes several seconds):
-
-- `Give a star <https://help.github.com/en/articles/saving-repositories-with-stars>`_ to its `GitHub repository <https://github.com/JiaweiZhuang/xESMF>`_.
+- `Give a star <https://help.github.com/en/articles/saving-repositories-with-stars>`_ to its `GitHub repository <https://github.com/pangeo-data/xESMF>`_.
 - Share it via social media like Twitter; introduce it to your friends/advisors/students.
 
 More advanced ways:

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -28,7 +28,7 @@ Getting xESMF is as simple as:
 
 .. warning::
 
-    One some platforms you might get :code:`ImportError: Regrid(filename) requires PIO and does not work if ESMF has not been built with MPI support`. (see `this comment <https://github.com/JiaweiZhuang/xESMF/issues/47#issuecomment-582421822>`_). A quick workaround is to constrain ESMPy version :code:`conda install -c conda-forge xesmf esmpy=7.1.0`.
+    One some platforms you might get :code:`ImportError: Regrid(filename) requires PIO and does not work if ESMF has not been built with MPI support`. (see `this comment <https://github.com/JiaweiZhuang/xESMF/issues/47#issuecomment-582421822>`_). A quick workaround is to constrain ESMPy version :code:`conda install -c conda-forge xesmf esmpy=8.0.0`.
 
 I also highly recommend those extra packages for full functionality:
 

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -6,14 +6,14 @@ Installation
 Try on Binder without local installation
 ----------------------------------------
 
-The `Binder project <https://mybinder.readthedocs.io>`_ provides pre-configured environment in the cloud. You just need a web browser to access it. Please follow the Binder link on `xESMF's GitHub page <https://github.com/JiaweiZhuang/xESMF>`_.
+The `Binder project <https://mybinder.readthedocs.io>`_ provides pre-configured environment in the cloud. You just need a web browser to access it. Please follow the Binder link on `xESMF's GitHub page <https://github.com/pangeo-data/xESMF>`_.
 
 Install on local machine with Conda
 -----------------------------------
 
-xESMF requires Python>=3.5. The major dependencies are xarray and ESMPy. The best way to install them is using Conda_.
+xESMF requires Python>=3.6. The major dependencies are xarray and ESMPy. The best way to install them is using Conda_.
 
-First, `install miniconda <https://docs.conda.io/projects/conda/en/latest/user-guide/install/index.html>`_. Then, I recommend creating a new, clean environment:
+First, `install miniconda <https://docs.conda.io/projects/conda/en/latest/user-guide/install/index.html>`_. Then, we recommend creating a new, clean environment:
 
 .. code-block:: bash
 
@@ -30,7 +30,7 @@ Getting xESMF is as simple as:
 
     One some platforms you might get :code:`ImportError: Regrid(filename) requires PIO and does not work if ESMF has not been built with MPI support`. (see `this comment <https://github.com/JiaweiZhuang/xESMF/issues/47#issuecomment-582421822>`_). A quick workaround is to constrain ESMPy version :code:`conda install -c conda-forge xesmf esmpy=8.0.0`.
 
-I also highly recommend those extra packages for full functionality:
+We also highly recommend those extra packages for full functionality:
 
 .. code-block:: bash
 
@@ -82,11 +82,11 @@ Install development version from GitHub repo
 
 To get the latest version that is not uploaded to PyPI_ yet::
 
-    $ pip install --upgrade git+https://github.com/JiaweiZhuang/xESMF.git
+    $ pip install --upgrade git+https://github.com/pangeo-data/xESMF.git
 
 Developers can track source code change::
 
-    $ git clone https://github.com/JiaweiZhuang/xESMF.git
+    $ git clone https://github.com/pangeo-data/xESMF.git
     $ cd xESMF
     $ pip install -e .
 

--- a/doc/other_tools.rst
+++ b/doc/other_tools.rst
@@ -3,7 +3,7 @@
 Other geospatial regridding tools
 =================================
 
-Here is a brief overview of other regridding tools that the author is aware of
+Here is a brief overview of other regridding tools that the authors are aware of
 (for geospatial data on the sphere, excluding traditional image resizing functions).
 They are all great tools and have helped the author a lot in both scientific research
 and xESMF development. Check them out if xESMF cannot suit your needs.
@@ -31,10 +31,9 @@ the daunting compiling process on your own.
 
 However, ESMPy is a complicated Python API that controls a huge Fortran beast
 hidden underneath. It is not as intuitive as native Python packages, and even
-a simple regridding task requires more than 10 lines of arcane code. That's why
-I made xESMF. If you want to involve in xESMF development you need to know ESMPy.
-Check out this nice
-`tutorial <https://github.com/nawendt/esmpy-tutorial>`_
+a simple regridding task requires more than 10 lines of arcane code. The
+purpose of xESMF is to provide a friendlier interface to the xarray community.
+Check out this nice `tutorial <https://github.com/nawendt/esmpy-tutorial>`_
 before going to the
 `official doc <http://www.earthsystemmodeling.org/esmf_releases/last_built/esmpy_doc/html/index.html>`_.
 

--- a/doc/why.rst
+++ b/doc/why.rst
@@ -40,7 +40,7 @@ For usability and simplicity
 
 :ref:`Current geospatial regridding tools <other_tools-label>` tend to have non-trivial learning curves.
 xESMF tries to be simple and intuitive.
-Instead of inventing a new data structure, it relies on well-estabilished standards
+Instead of inventing a new data structure, it relies on well-established standards
 (numpy and xarray), so users don't need to learn a bunch of new syntaxes or even a new software stack.
 
 xESMF can track metadata in ``xarray.DataArray`` / ``xarray.Dataset``, and


### PR DESCRIPTION
Quick clean-up of documentation. 

- Updated links pointing at previous github repo
- Replaced "I" by "we" 
- Update esmpy version in installation docs.
