### PR TITLE
fix API in documentation

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -17,9 +17,10 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-# import os
-# import sys
-# sys.path.insert(0, os.path.abspath('..'))
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath('..'))
 
 
 # -- General configuration ------------------------------------------------

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -6,3 +6,4 @@ Pygments>=2.6
 nbsphinx
 sphinx==3.2.1
 sphinx_rtd_theme
+cf_xarray


### PR DESCRIPTION
I've noticed that the documentation was not building correctly the Regridder API: https://pangeo-xesmf.readthedocs.io/en/latest/user_api.html#regridder

This should fix it (it's working on my local machine).
