### PR TITLE
Fix tarball check

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -9,5 +9,8 @@ prune binder
 prune *.egg-info
 
 exclude *.yml
+exclude *.yaml
+exclude .*.toml
+exclude .*.txt
 exclude .gitignore
 exclude xesmf/_version.py


### PR DESCRIPTION
The GitHub Action that creates the tarball was failing b/c these files failed the MANIFEST check. This is not too important but it is nice to get this test fixed b/c when we add a file that we do want in the tarball we can catch the failure and fix it early.