### PR TITLE
bug fix read lon/lat

### DIFF
--- a/ci/environment-upstream-dev.yml
+++ b/ci/environment-upstream-dev.yml
@@ -8,6 +8,7 @@ dependencies:
   - numpy
   - pip
   - pre-commit
+  - pydap
   - pytest
   - pytest-cov
   - scipy

--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -9,6 +9,7 @@ dependencies:
   - numpy
   - pip
   - pre-commit
+  - pydap
   - pytest
   - pytest-cov
   - scipy

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,7 +8,7 @@ extend-ignore = E203,E501,E402,W605
 
 [isort]
 known_first_party=xesmf
-known_third_party=ESMF,cf_xarray,dask,numpy,pytest,scipy,setuptools,shapely,xarray
+known_third_party=ESMF,cf_xarray,dask,numpy,pydap,pytest,scipy,setuptools,shapely,xarray
 multi_line_output=3
 include_trailing_comma=True
 force_grid_wrap=0

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,7 +8,7 @@ extend-ignore = E203,E501,E402,W605
 
 [isort]
 known_first_party=xesmf
-known_third_party=ESMF,cf_xarray,dask,numpy,pydap,pytest,scipy,setuptools,shapely,xarray
+known_third_party=ESMF,cf_xarray,dask,numpy,pytest,scipy,setuptools,shapely,xarray
 multi_line_output=3
 include_trailing_comma=True
 force_grid_wrap=0

--- a/xesmf/frontend.py
+++ b/xesmf/frontend.py
@@ -36,14 +36,17 @@ def as_2d_mesh(lon, lat):
 
 def _get_lon_lat(ds):
     """Return lon and lat extracted from ds."""
+    if 'lat' in ds and 'lon' in ds:
+        # Old way.
+        return ds['lon'], ds['lat']
+    # else : cf-xarray way
     try:
         lon = ds.cf['longitude']
         lat = ds.cf['latitude']
-    except (KeyError, AttributeError):
+    except (KeyError, AttributeError, ValueError):
         # KeyError if cfxr doesn't detect the coords
         # AttributeError if ds is a dict
-        lon = ds['lon']
-        lat = ds['lat']
+        raise ValueError('dataset must include lon/lat or be CF-compliant')
 
     return lon, lat
 

--- a/xesmf/tests/conftest.py
+++ b/xesmf/tests/conftest.py
@@ -25,3 +25,21 @@ def distributed_scheduler():
     del client
     cluster.close()
     del cluster
+
+
+def pytest_addoption(parser):
+    parser.addoption("--runtestcases", action="store_true", default=False, help="run test cases")
+
+
+def pytest_configure(config):
+    config.addinivalue_line("markers", "testcases: mark test cases")
+
+
+def pytest_collection_modifyitems(config, items):
+    if config.getoption("--runtestcases"):
+        # --runtestcases given in cli: do not skip test cases
+        return
+    skip_testcases = pytest.mark.skip(reason="need --runtestcases option to run")
+    for item in items:
+        if "testcases" in item.keywords:
+            item.add_marker(skip_testcases)

--- a/xesmf/tests/conftest.py
+++ b/xesmf/tests/conftest.py
@@ -28,7 +28,7 @@ def distributed_scheduler():
 
 
 def pytest_addoption(parser):
-    parser.addoption("--runtestcases", action='store_true', default=False, help='run test cases')
+    parser.addoption('--runtestcases', action='store_true', default=False, help='run test cases')
 
 
 def pytest_configure(config):

--- a/xesmf/tests/conftest.py
+++ b/xesmf/tests/conftest.py
@@ -28,18 +28,18 @@ def distributed_scheduler():
 
 
 def pytest_addoption(parser):
-    parser.addoption("--runtestcases", action="store_true", default=False, help="run test cases")
+    parser.addoption("--runtestcases", action='store_true', default=False, help='run test cases')
 
 
 def pytest_configure(config):
-    config.addinivalue_line("markers", "testcases: mark test cases")
+    config.addinivalue_line('markers', 'testcases: mark test cases')
 
 
 def pytest_collection_modifyitems(config, items):
-    if config.getoption("--runtestcases"):
+    if config.getoption('--runtestcases'):
         # --runtestcases given in cli: do not skip test cases
         return
-    skip_testcases = pytest.mark.skip(reason="need --runtestcases option to run")
+    skip_testcases = pytest.mark.skip(reason='need --runtestcases option to run')
     for item in items:
-        if "testcases" in item.keywords:
+        if 'testcases' in item.keywords:
             item.add_marker(skip_testcases)

--- a/xesmf/tests/test_oceanmodels.py
+++ b/xesmf/tests/test_oceanmodels.py
@@ -4,9 +4,10 @@ import warnings
 import cf_xarray  # noqa
 import dask
 import numpy as np
+import pydap
 import pytest
 import xarray as xr
-import pydap
+
 import xesmf
 
 

--- a/xesmf/tests/test_oceanmodels.py
+++ b/xesmf/tests/test_oceanmodels.py
@@ -1,13 +1,6 @@
-import os
-import warnings
-
 import cf_xarray  # noqa
-import dask
 import numpy as np
-import pydap
-import pytest
 import xarray as xr
-
 import xesmf
 
 

--- a/xesmf/tests/test_oceanmodels.py
+++ b/xesmf/tests/test_oceanmodels.py
@@ -1,6 +1,7 @@
 import cf_xarray  # noqa
 import numpy as np
 import xarray as xr
+
 import xesmf
 
 
@@ -12,6 +13,7 @@ def test_MOM6_to_1x1():
         f'{dataurl}/ocean_monthly_z.200301-200712.nc4',
         chunks={'time': 1, 'z_l': 1},
         drop_variables=['average_DT', 'average_T1', 'average_T2'],
+        decode_times=False,
         engine='pydap',
     )
 

--- a/xesmf/tests/test_oceanmodels.py
+++ b/xesmf/tests/test_oceanmodels.py
@@ -1,0 +1,31 @@
+import os
+import warnings
+
+import cf_xarray  # noqa
+import dask
+import numpy as np
+import pytest
+import xarray as xr
+import pydap
+import xesmf
+
+
+def test_MOM6_to_1x1():
+    """ check regridding of MOM6 to regular lon/lat """
+
+    dataurl = 'http://35.188.34.63:8080/thredds/dodsC/OM4p5/'
+    MOM6 = xr.open_dataset(f'{dataurl}/ocean_monthly_z.200301-200712.nc4',
+                           chunks={'time':1, 'z_l': 1},
+                           drop_variables=['average_DT', 'average_T1', 'average_T2'],
+                           engine='pydap')
+
+    grid_1x1 = xr.Dataset()
+    grid_1x1['lon'] = xr.DataArray(data=0.5 + np.arange(360), dims=('x'))
+    grid_1x1['lat'] = xr.DataArray(data=0.5 -90 + np.arange(180), dims=('y'))
+
+    regrid_to_1x1 = xesmf.Regridder(MOM6.rename({'geolon': 'lon',
+                                                 'geolat': 'lat'}),
+                                                  grid_1x1, 'bilinear', periodic=True)
+
+    thetao_1x1 = regrid_to_1x1(MOM6['thetao'])
+    assert np.allclose(thetao_1x1.isel(time=0, z_l=0, x=200, y=100).values, 27.15691922)

--- a/xesmf/tests/test_oceanmodels.py
+++ b/xesmf/tests/test_oceanmodels.py
@@ -1,10 +1,12 @@
 import cf_xarray  # noqa
 import numpy as np
+import pytest
 import xarray as xr
 
 import xesmf
 
 
+@pytest.mark.testcases
 def test_MOM6_to_1x1():
     """ check regridding of MOM6 to regular lon/lat """
 

--- a/xesmf/tests/test_oceanmodels.py
+++ b/xesmf/tests/test_oceanmodels.py
@@ -15,18 +15,20 @@ def test_MOM6_to_1x1():
     """ check regridding of MOM6 to regular lon/lat """
 
     dataurl = 'http://35.188.34.63:8080/thredds/dodsC/OM4p5/'
-    MOM6 = xr.open_dataset(f'{dataurl}/ocean_monthly_z.200301-200712.nc4',
-                           chunks={'time':1, 'z_l': 1},
-                           drop_variables=['average_DT', 'average_T1', 'average_T2'],
-                           engine='pydap')
+    MOM6 = xr.open_dataset(
+        f'{dataurl}/ocean_monthly_z.200301-200712.nc4',
+        chunks={'time': 1, 'z_l': 1},
+        drop_variables=['average_DT', 'average_T1', 'average_T2'],
+        engine='pydap',
+    )
 
     grid_1x1 = xr.Dataset()
     grid_1x1['lon'] = xr.DataArray(data=0.5 + np.arange(360), dims=('x'))
-    grid_1x1['lat'] = xr.DataArray(data=0.5 -90 + np.arange(180), dims=('y'))
+    grid_1x1['lat'] = xr.DataArray(data=0.5 - 90 + np.arange(180), dims=('y'))
 
-    regrid_to_1x1 = xesmf.Regridder(MOM6.rename({'geolon': 'lon',
-                                                 'geolat': 'lat'}),
-                                                  grid_1x1, 'bilinear', periodic=True)
+    regrid_to_1x1 = xesmf.Regridder(
+        MOM6.rename({'geolon': 'lon', 'geolat': 'lat'}), grid_1x1, 'bilinear', periodic=True
+    )
 
     thetao_1x1 = regrid_to_1x1(MOM6['thetao'])
     assert np.allclose(thetao_1x1.isel(time=0, z_l=0, x=200, y=100).values, 27.15691922)


### PR DESCRIPTION
Well this is embarrassing and quite urgent. Looks like PR #49 broke my regridding of MOM6 data.
The default behavior is now a breaking change and I did not catch it in my review. I strongly think
that the default behavior should mimic the old behavior (i.e. looking for `lon` and `lat` in dataset).

This PR reintroduce the old behavior and only switch to using cf-xaray if `lon` and `lat` are not present.
I also added a realistic test case using MOM6 ocean data pulled from opendap to avoid another bad surprise
in the future.

@huard @aulemahal I'd like us to move quickly on this and we probably need to push another release soon too!