### PR TITLE
Add basic adaptive masking to solve #29

### DIFF
--- a/xesmf/frontend.py
+++ b/xesmf/frontend.py
@@ -426,27 +426,18 @@ class BaseRegridder(object):
 
         """
         if isinstance(indata, np.ndarray):
-            return self.regrid_numpy(
-                indata,
-                adaptative_masking=adaptative_masking)
+            return self.regrid_numpy(indata, adaptative_masking=adaptative_masking)
         elif isinstance(indata, dask_array_type):
-            return self.regrid_dask(
-                indata,
-                adaptative_masking=adaptative_masking)
+            return self.regrid_dask(indata, adaptative_masking=adaptative_masking)
         elif isinstance(indata, xr.DataArray):
             return self.regrid_dataarray(
-                indata,
-                keep_attrs=keep_attrs,
-                adaptative_masking=adaptative_masking)
+                indata, keep_attrs=keep_attrs, adaptative_masking=adaptative_masking)
         elif isinstance(indata, xr.Dataset):
             return self.regrid_dataset(
-                indata,
-                keep_attrs=keep_attrs,
-                adaptative_masking=adaptative_masking)
+                indata, eep_attrs=keep_attrs, adaptative_masking=adaptative_masking)
         else:
             raise TypeError(
-                'input must be numpy array, dask array, '
-                'xarray DataArray or Dataset!'
+                'input must be numpy array, dask array, xarray DataArray or Dataset!'
             )
 
     @staticmethod
@@ -460,7 +451,7 @@ class BaseRegridder(object):
             mask_threshold = float(not adaptative_masking)
         elif adaptative_masking >= 1 or adaptative_masking < 0:
             adaptative_masking = False
-            mask_threshold = 1.
+            mask_threshold = 1.0
         else:
             mask_threshold = float(adaptative_masking)
             adaptative_masking = True
@@ -474,9 +465,9 @@ class BaseRegridder(object):
             has_non_perm_mask = (many == mall).all()
             if not adaptative_masking and has_non_perm_mask:
                 warnings.warn(
-                    "Your data has transient missing values. "
-                    "You should set adaptative_masking to True, "
-                    "which will be the default in future versions.")
+                    'Your data has transient missing values. '
+                    'You should set adaptative_masking to True, '
+                    'which will be the default in future versions.')
             if adaptative_masking:
                 inmask = np.isnan(indata)
                 indata = indata.copy()
@@ -491,7 +482,7 @@ class BaseRegridder(object):
         if adaptative_masking:
             outvalid = apply_weights(weights, (~inmask).astype('d'), shape_in, shape_out)
             tol = 1e-6
-            bad = outvalid < min(max(mask_threshold, tol), 1-tol)
+            bad = outvalid < min(max(mask_threshold, tol), 1 - tol)
             outvalid[bad] = 1
             outdata = xr.where(bad, np.nan, outdata / outvalid)
 
@@ -506,17 +497,13 @@ class BaseRegridder(object):
             'shape_out': self.shape_out,
         }
 
-    def regrid_numpy(
-            self, indata, adaptative_masking=False):
+    def regrid_numpy(self, indata, adaptative_masking=False):
         """See __call__()."""
         outdata = self._regrid_array(
-            indata,
-            adaptative_masking=adaptative_masking,
-            **self._regrid_kwargs)
+            indata, adaptative_masking=adaptative_masking, **self._regrid_kwargs)
         return outdata
 
-    def regrid_dask(
-            self, indata, adaptative_masking=False):
+    def regrid_dask(self, indata, adaptative_masking=False):
         """See __call__()."""
 
         extra_chunk_shape = indata.chunksize[0:-2]

--- a/xesmf/frontend.py
+++ b/xesmf/frontend.py
@@ -465,7 +465,7 @@ class BaseRegridder(object):
         if adaptative_masking:
             outvalid = apply_weights(
                 weights, (~inmask).astype('d'), shape_in, shape_out)
-            bad = np.isclose(outvalid, 0, atol=1e-6)
+            bad = np.isclose(outvalid, 0, atol=mask_threshold)
             outvalid[bad] = 1
             outdata = xr.where(bad, np.nan, outdata / outvalid)
 

--- a/xesmf/frontend.py
+++ b/xesmf/frontend.py
@@ -440,7 +440,7 @@ class BaseRegridder(object):
         if adaptative_masking:
             outvalid = apply_weights(
                 weights, (~inmask).astype('d'), shape_in, shape_out)
-            bad = outvalid == 0
+            bad = np.isclose(outvalid, 0)
             outvalid[bad] = 1
             outdata = xr.where(bad, np.nan, outdata / outvalid)
 

--- a/xesmf/frontend.py
+++ b/xesmf/frontend.py
@@ -370,7 +370,7 @@ class BaseRegridder(object):
         esmf_regrid_finalize(regrid)  # only need weights, not regrid object
         return w
 
-    def __call__(self, indata, keep_attrs=False, adaptative_masking=False):
+    def __call__(self, indata, keep_attrs=False, skipna=False, na_thres=1.):
         """
         Apply regridding to input data.
 
@@ -395,21 +395,26 @@ class BaseRegridder(object):
             Keep attributes for xarray DataArrays or Datasets.
             Defaults to False.
 
-        adaptative_masking: bool, float, optional
-            Set it to True to properly handle transient missing values,
-            i.e. when the number of missing values varies along dimensions
-            other than the horizontal ones.
-            In case of a float, the value is interpreted as a threshold.
-            The mask is converted to float with 1 for valid values and 0 for nans.
-            The destination grid
-            point is masked if the interpolated mask is above this threshold.
-            A value close to zero means that the destination point is
-            masked if all sources points are masked.
-            The threshold must be have a value within the [0., 1.].
-            When >= 1 or equal to 0, adaptative_masking is set to False, else
-            it is set to True.
+        skipna: bool, optional
+            Whether to skip missing values when regridding.
+            When set to False, an output value is masked when a single
+            input value that is is missing and no grid mask is provided.
+            When set to True, missing values do not contaminate the regridding
+            since only valid values are taken into account.
+            In this case, a given output point is set to NaN only if the ratio
+            of missing values exceeds the level set by `na_thres`:
+            for instance, when the center of a cell is computed linearly
+            from its four corners, one of which is missing, the output value
+            is set to NaN if `na_thres` is greater or equal to 0.25.
 
-            .. note:: It will be set to True in futures versions.
+        na_thres: float, optional
+            A value within the [0., 1.] interval that defines the maximum
+            ratio of missing grid points involved in the regrdding over which
+            the output value is set to NaN. For instance, if `na_thres` is set
+            to 0, the output value is NaN if a single NaN is found in the input
+            values that are used to compute the output value; similarly,
+            if `na_thres` is set to 1, all inpput values must be missing to
+            mask the output value.
 
         Returns
         -------
@@ -426,66 +431,55 @@ class BaseRegridder(object):
 
         """
         if isinstance(indata, np.ndarray):
-            return self.regrid_numpy(indata, adaptative_masking=adaptative_masking)
+            return self.regrid_numpy(
+                indata,
+                skipna=skipna,
+                na_thres=na_thres)
         elif isinstance(indata, dask_array_type):
-            return self.regrid_dask(indata, adaptative_masking=adaptative_masking)
+            return self.regrid_dask(
+                indata,
+                skipna=skipna,
+                na_thres=na_thres)
         elif isinstance(indata, xr.DataArray):
             return self.regrid_dataarray(
-                indata, keep_attrs=keep_attrs, adaptative_masking=adaptative_masking
-            )
+                indata,
+                keep_attrs=keep_attrs,
+                skipna=skipna,
+                na_thres=na_thres)
         elif isinstance(indata, xr.Dataset):
             return self.regrid_dataset(
-                indata, keep_attrs=keep_attrs, adaptative_masking=adaptative_masking
-            )
+                indata,
+                keep_attrs=keep_attrs,
+                skipna=skipna,
+                na_thres=na_thres)
         else:
-            raise TypeError('input must be numpy array, dask array, xarray DataArray or Dataset!')
+            raise TypeError(
+                'input must be numpy array, dask array, xarray DataArray or Dataset!'
+            )
 
     @staticmethod
-    def _regrid_array(indata, *, weights, shape_in, shape_out, sequence_in, adaptative_masking):
+    def _regrid_array(
+            indata, *, weights, shape_in, shape_out, sequence_in, skipna, na_thres):
 
         if sequence_in:
             indata = np.expand_dims(indata, axis=-2)
 
-        # interpreting adaptative_masking
-        if isinstance(adaptative_masking, bool):
-            mask_threshold = float(not adaptative_masking)
-        elif adaptative_masking >= 1 or adaptative_masking < 0:
-            adaptative_masking = False
-            mask_threshold = 1.0
-        else:
-            mask_threshold = float(adaptative_masking)
-            adaptative_masking = True
-
-        # is there any non-permament missing values?
-        ndim = np.ndim(indata)
-        if ndim > 2:
-            inmask = np.isnan(indata)
-            many = np.apply_over_axes(np.any, inmask, [-2, -1])
-            mall = np.apply_over_axes(np.all, inmask, [-2, -1])
-            has_non_perm_mask = (many == mall).all()
-            if not adaptative_masking and has_non_perm_mask:
-                warnings.warn(
-                    'Your data has transient missing values. '
-                    'You should set adaptative_masking to True, '
-                    'which will be the default in future versions.'
-                )
-            if adaptative_masking:
-                inmask = np.isnan(indata)
-                indata = indata.copy()
-                indata[inmask] = 0  # does it work with dask?
-        else:
-            adaptative_masking = False
+        # skipna: set missing values to zero
+        if skipna:
+            missing = np.isnan(indata)
+            indata = np.where(missing, 0., indata)
 
         # apply weights
         outdata = apply_weights(weights, indata, shape_in, shape_out)
 
-        # scale the data
-        if adaptative_masking:
-            outvalid = apply_weights(weights, (~inmask).astype('d'), shape_in, shape_out)
+        # skipna: scale the data
+        if skipna:
+            fraction_valid = apply_weights(
+                weights, (~missing).astype('d'), shape_in, shape_out)
             tol = 1e-6
-            bad = outvalid < min(max(mask_threshold, tol), 1 - tol)
-            outvalid[bad] = 1
-            outdata = xr.where(bad, np.nan, outdata / outvalid)
+            bad = fraction_valid < np.clip(1-na_thres, tol, 1-tol)
+            fraction_valid[bad] = 1
+            outdata = np.where(bad, np.nan, outdata / fraction_valid)
 
         return outdata
 
@@ -498,14 +492,17 @@ class BaseRegridder(object):
             'shape_out': self.shape_out,
         }
 
-    def regrid_numpy(self, indata, adaptative_masking=False):
+    def regrid_numpy(self, indata, skipna=False, na_thres=1.):
         """See __call__()."""
         outdata = self._regrid_array(
-            indata, adaptative_masking=adaptative_masking, **self._regrid_kwargs
+            indata,
+            skipna=skipna,
+            na_thres=na_thres,
+            **self._regrid_kwargs
         )
         return outdata
 
-    def regrid_dask(self, indata, adaptative_masking=False):
+    def regrid_dask(self, indata, skipna=False, na_thres=1.):
         """See __call__()."""
 
         extra_chunk_shape = indata.chunksize[0:-2]
@@ -517,18 +514,19 @@ class BaseRegridder(object):
             indata,
             dtype=float,
             chunks=output_chunk_shape,
-            adaptative_masking=adaptative_masking,
+            skipna=skipna,
+            na_thres=na_thres,
             **self._regrid_kwargs,
         )
 
         return outdata
 
-    def regrid_dataarray(self, dr_in, keep_attrs=False, adaptative_masking=False):
+    def regrid_dataarray(self, dr_in, keep_attrs=False, skipna=False, na_thres=1.):
         """See __call__()."""
 
         input_horiz_dims, temp_horiz_dims = self._parse_xrinput(dr_in)
-        kwargs = self._regrid_kwargs
-        kwargs.update(adaptative_masking=adaptative_masking)
+        kwargs = self._regrid_kwargs.copy()
+        kwargs.update(skipna=skipna, na_thres=na_thres)
         dr_out = xr.apply_ufunc(
             self._regrid_array,
             dr_in,
@@ -546,14 +544,14 @@ class BaseRegridder(object):
 
         return self._format_xroutput(dr_out, temp_horiz_dims)
 
-    def regrid_dataset(self, ds_in, keep_attrs=False, adaptative_masking=False):
+    def regrid_dataset(self, ds_in, keep_attrs=False, skipna=False, na_thres=1.):
         """See __call__()."""
 
         # get the first data variable to infer input_core_dims
         input_horiz_dims, temp_horiz_dims = self._parse_xrinput(ds_in)
 
-        kwargs = self._regrid_kwargs
-        kwargs.update(adaptative_masking=adaptative_masking)
+        kwargs = self._regrid_kwargs.copy()
+        kwargs.update(skipna=skipna, na_thres=na_thres)
 
         non_regriddable = [
             name

--- a/xesmf/frontend.py
+++ b/xesmf/frontend.py
@@ -459,7 +459,7 @@ class BaseRegridder(object):
         # apply weights
         outdata = apply_weights(weights, indata, shape_in, shape_out)
 
-        # skipna: scale the data
+        # skipna: Compute the influence of missing data at each interpolation point and filter those not meeting acceptable  threshold. 
         if skipna:
             fraction_valid = apply_weights(weights, (~missing).astype('d'), shape_in, shape_out)
             tol = 1e-6

--- a/xesmf/frontend.py
+++ b/xesmf/frontend.py
@@ -398,7 +398,7 @@ class BaseRegridder(object):
         skipna: bool, optional
             Whether to skip missing values when regridding.
             When set to False, an output value is masked when a single
-            input value that is is missing and no grid mask is provided.
+            input value is missing and no grid mask is provided.
             When set to True, missing values do not contaminate the regridding
             since only valid values are taken into account.
             In this case, a given output point is set to NaN only if the ratio

--- a/xesmf/frontend.py
+++ b/xesmf/frontend.py
@@ -413,7 +413,7 @@ class BaseRegridder(object):
             the output value is set to NaN. For instance, if `na_thres` is set
             to 0, the output value is NaN if a single NaN is found in the input
             values that are used to compute the output value; similarly,
-            if `na_thres` is set to 1, all inpput values must be missing to
+            if `na_thres` is set to 1, all input values must be missing to
             mask the output value.
 
         Returns
@@ -459,7 +459,7 @@ class BaseRegridder(object):
         # apply weights
         outdata = apply_weights(weights, indata, shape_in, shape_out)
 
-        # skipna: Compute the influence of missing data at each interpolation point and filter those not meeting acceptable  threshold. 
+        # skipna: Compute the influence of missing data at each interpolation point and filter those not meeting acceptable threshold.
         if skipna:
             fraction_valid = apply_weights(weights, (~missing).astype('d'), shape_in, shape_out)
             tol = 1e-6

--- a/xesmf/frontend.py
+++ b/xesmf/frontend.py
@@ -434,7 +434,7 @@ class BaseRegridder(object):
                 indata, keep_attrs=keep_attrs, adaptative_masking=adaptative_masking)
         elif isinstance(indata, xr.Dataset):
             return self.regrid_dataset(
-                indata, eep_attrs=keep_attrs, adaptative_masking=adaptative_masking)
+                indata, keep_attrs=keep_attrs, adaptative_masking=adaptative_masking)
         else:
             raise TypeError(
                 'input must be numpy array, dask array, xarray DataArray or Dataset!'

--- a/xesmf/frontend.py
+++ b/xesmf/frontend.py
@@ -431,14 +431,14 @@ class BaseRegridder(object):
             return self.regrid_dask(indata, adaptative_masking=adaptative_masking)
         elif isinstance(indata, xr.DataArray):
             return self.regrid_dataarray(
-                indata, keep_attrs=keep_attrs, adaptative_masking=adaptative_masking)
+                indata, keep_attrs=keep_attrs, adaptative_masking=adaptative_masking
+            )
         elif isinstance(indata, xr.Dataset):
             return self.regrid_dataset(
-                indata, keep_attrs=keep_attrs, adaptative_masking=adaptative_masking)
-        else:
-            raise TypeError(
-                'input must be numpy array, dask array, xarray DataArray or Dataset!'
+                indata, keep_attrs=keep_attrs, adaptative_masking=adaptative_masking
             )
+        else:
+            raise TypeError('input must be numpy array, dask array, xarray DataArray or Dataset!')
 
     @staticmethod
     def _regrid_array(indata, *, weights, shape_in, shape_out, sequence_in, adaptative_masking):
@@ -467,7 +467,8 @@ class BaseRegridder(object):
                 warnings.warn(
                     'Your data has transient missing values. '
                     'You should set adaptative_masking to True, '
-                    'which will be the default in future versions.')
+                    'which will be the default in future versions.'
+                )
             if adaptative_masking:
                 inmask = np.isnan(indata)
                 indata = indata.copy()
@@ -500,7 +501,8 @@ class BaseRegridder(object):
     def regrid_numpy(self, indata, adaptative_masking=False):
         """See __call__()."""
         outdata = self._regrid_array(
-            indata, adaptative_masking=adaptative_masking, **self._regrid_kwargs)
+            indata, adaptative_masking=adaptative_masking, **self._regrid_kwargs
+        )
         return outdata
 
     def regrid_dask(self, indata, adaptative_masking=False):

--- a/xesmf/tests/test_frontend.py
+++ b/xesmf/tests/test_frontend.py
@@ -573,16 +573,16 @@ def test_polys_to_ESMFmesh():
 @pytest.mark.parametrize(
     'method, skipna, na_thres, nvalid',
     [
-        ('bilinear', False, 1., 380),
-        ('bilinear', True, 1., 395),
-        ('bilinear', True, 0., 380),
+        ('bilinear', False, 1.0, 380),
+        ('bilinear', True, 1.0, 395),
+        ('bilinear', True, 0.0, 380),
         ('bilinear', True, 0.5, 388),
-        ('bilinear', True, 1., 395),
-        ('conservative', False, 1., 385),
-        ('conservative', True, 1., 394),
-        ('conservative', True, 0., 385),
+        ('bilinear', True, 1.0, 395),
+        ('conservative', False, 1.0, 385),
+        ('conservative', True, 1.0, 394),
+        ('conservative', True, 0.0, 385),
         ('conservative', True, 0.5, 388),
-        ('conservative', True, 1., 394),
+        ('conservative', True, 1.0, 394),
     ],
 )
 def test_skipna(method, skipna, na_thres, nvalid):

--- a/xesmf/tests/test_frontend.py
+++ b/xesmf/tests/test_frontend.py
@@ -571,25 +571,25 @@ def test_polys_to_ESMFmesh():
 
 
 @pytest.mark.parametrize(
-    'method, adaptative_masking, nvalid',
+    'method, skipna, na_thres, nvalid',
     [
-        ('bilinear', False, 380),
-        ('bilinear', True, 395),
-        ('bilinear', 1, 380),
-        ('bilinear', 0.5, 388),
-        ('bilinear', 0, 395),
-        ('conservative', False, 385),
-        ('conservative', True, 394),
-        ('conservative', 1, 385),
-        ('conservative', 0.5, 388),
-        ('conservative', 0, 394),
+        ('bilinear', False, 1., 380),
+        ('bilinear', True, 1., 395),
+        ('bilinear', True, 0., 380),
+        ('bilinear', True, 0.5, 388),
+        ('bilinear', True, 1., 395),
+        ('conservative', False, 1., 385),
+        ('conservative', True, 1., 394),
+        ('conservative', True, 0., 385),
+        ('conservative', True, 0.5, 388),
+        ('conservative', True, 1., 394),
     ],
 )
-def test_adaptative_masking(method, adaptative_masking, nvalid):
+def test_skipna(method, skipna, na_thres, nvalid):
     dai = ds_in['data4D'].copy()
     dai[0, 0, 4:6, 4:6] = np.nan
     rg = xe.Regridder(ds_in, ds_out, method)
-    dao = rg(dai, adaptative_masking=adaptative_masking)
+    dao = rg(dai, skipna=skipna, na_thres=na_thres)
     assert int(dao[0, 0, 1:-1, 1:-1].notnull().sum()) == nvalid
 
 

--- a/xesmf/tests/test_frontend.py
+++ b/xesmf/tests/test_frontend.py
@@ -535,15 +535,15 @@ def test_polys_to_ESMFmesh():
 
 
 @pytest.mark.parametrize(
-    "method, adaptative_masking, nmissing", [
-        ("bilinear", False, 36944),
-        ("bilinear", True, 30491),
-        ("conservative", False, 36949),
-        ("conservative", True, 36958)
+    "method, adaptative_masking, nvalid", [
+        ("bilinear", False, 380),
+        ("bilinear", True, 395),
+        ("conservative", False, 385),
+        ("conservative", True, 394)
         ])
-def test_adaptative_masking(method, adaptative_masking, nmissing):
+def test_adaptative_masking(method, adaptative_masking, nvalid):
     dai = ds_in["data4D"].copy()
     dai[0, 0, 4:6, 4:6] = np.nan
     rg = xe.Regridder(ds_in, ds_out, method)
     dao = rg(dai, adaptative_masking=adaptative_masking)
-    assert int(dao.notnull().sum()) == nmissing
+    assert int(dao[0, 0, 1:-1, 1:-1].notnull().sum()) == nvalid

--- a/xesmf/tests/test_frontend.py
+++ b/xesmf/tests/test_frontend.py
@@ -532,3 +532,18 @@ def test_polys_to_ESMFmesh():
     assert shape == (1, 4)
     assert len(rec) == 1
     assert 'Some passed polygons have holes' in rec[0].message.args[0]
+
+
+@pytest.mark.parametrize(
+    "method, adaptative_masking, nmissing", [
+        ("bilinear", False, 36944),
+        ("bilinear", True, 30491),
+        ("conservative", False, 36949),
+        ("conservative", True, 36958)
+        ])
+def test_adaptative_masking(method, adaptative_masking, nmissing):
+    dai = ds_in["data4D"].copy()
+    dai[0, 0, 4:6, 4:6] = np.nan
+    rg = xe.Regridder(ds_in, ds_out, method)
+    dao = rg(dai, adaptative_masking=adaptative_masking)
+    assert int(dao.notnull().sum()) == nmissing

--- a/xesmf/tests/test_frontend.py
+++ b/xesmf/tests/test_frontend.py
@@ -571,20 +571,20 @@ def test_polys_to_ESMFmesh():
 
 
 @pytest.mark.parametrize(
-    "method, adaptative_masking, nvalid", [
-        ("bilinear", False, 380),
-        ("bilinear", True, 395),
-        ("bilinear", 1, 380),
-        ("bilinear", 0.5, 388),
-        ("bilinear", 0, 395),
-        ("conservative", False, 385),
-        ("conservative", True, 394),
-        ("conservative", 1, 385),
-        ("conservative", 0.5, 388),
-        ("conservative", 0, 394),
+    'method, adaptative_masking, nvalid', [
+        ('bilinear', False, 380),
+        ('bilinear', True, 395),
+        ('bilinear', 1, 380),
+        ('bilinear', 0.5, 388),
+        ('bilinear', 0, 395),
+        ('conservative', False, 385),
+        ('conservative', True, 394),
+        ('conservative', 1, 385),
+        ('conservative', 0.5, 388),
+        ('conservative', 0, 394),
         ])
 def test_adaptative_masking(method, adaptative_masking, nvalid):
-    dai = ds_in["data4D"].copy()
+    dai = ds_in['data4D'].copy()
     dai[0, 0, 4:6, 4:6] = np.nan
     rg = xe.Regridder(ds_in, ds_out, method)
     dao = rg(dai, adaptative_masking=adaptative_masking)

--- a/xesmf/tests/test_frontend.py
+++ b/xesmf/tests/test_frontend.py
@@ -571,7 +571,8 @@ def test_polys_to_ESMFmesh():
 
 
 @pytest.mark.parametrize(
-    'method, adaptative_masking, nvalid', [
+    'method, adaptative_masking, nvalid',
+    [
         ('bilinear', False, 380),
         ('bilinear', True, 395),
         ('bilinear', 1, 380),
@@ -582,7 +583,8 @@ def test_polys_to_ESMFmesh():
         ('conservative', 1, 385),
         ('conservative', 0.5, 388),
         ('conservative', 0, 394),
-        ])
+    ],
+)
 def test_adaptative_masking(method, adaptative_masking, nvalid):
     dai = ds_in['data4D'].copy()
     dai[0, 0, 4:6, 4:6] = np.nan


### PR DESCRIPTION
As explained in #29, the regridding leads to unexpected results when the input dataset has transient values i.e. when the number of missing values varies along dimensions other than the horizontal ones.

This PR fixes #29 by normalising the results with the regridded transient mask.