### PR TITLE
Fix lon/lat extraction for DataArrays

### DIFF
--- a/xesmf/frontend.py
+++ b/xesmf/frontend.py
@@ -36,7 +36,7 @@ def as_2d_mesh(lon, lat):
 
 def _get_lon_lat(ds):
     """Return lon and lat extracted from ds."""
-    if 'lat' in ds and 'lon' in ds:
+    if 'lat' in ds.coords and 'lon' in ds.coords:
         # Old way.
         return ds['lon'], ds['lat']
     # else : cf-xarray way

--- a/xesmf/frontend.py
+++ b/xesmf/frontend.py
@@ -36,7 +36,7 @@ def as_2d_mesh(lon, lat):
 
 def _get_lon_lat(ds):
     """Return lon and lat extracted from ds."""
-    if 'lat' in ds.coords and 'lon' in ds.coords:
+    if ('lat' in ds and 'lon' in ds) or ('lat' in ds.coords and 'lon' in ds.coords):
         # Old way.
         return ds['lon'], ds['lat']
     # else : cf-xarray way

--- a/xesmf/tests/test_frontend.py
+++ b/xesmf/tests/test_frontend.py
@@ -547,3 +547,12 @@ def test_polys_to_ESMFmesh():
     assert shape == (1, 4)
     assert len(rec) == 1
     assert 'Some passed polygons have holes' in rec[0].message.args[0]
+
+
+def test_non_cf_latlon():
+    ds_in_noncf = ds_in.copy()
+    ds_in_noncf.lon.attrs = {}
+    ds_in_noncf.lat.attrs = {}
+    # Test non-CF lat/lon extraction for both DataArray and Dataset
+    xe.Regridder(ds_in_noncf['data'], ds_out, 'bilinear')
+    xe.Regridder(ds_in_noncf, ds_out, 'bilinear')


### PR DESCRIPTION
The fix in #64 for extracting lat/lon from non-cf-compliant fields didn't work if the input was a DataArray. This is a simple change to check for lat/lon with the `.coords` method, which works for either DataArrays or Datasets.