### PR TITLE
Allow non-regriddable vars in datasets

### DIFF
--- a/xesmf/tests/test_frontend.py
+++ b/xesmf/tests/test_frontend.py
@@ -471,6 +471,10 @@ def test_regrid_dataset():
     assert_equal(ds_result['lat'].values, ds_out['lat'].values)
     assert_equal(ds_result['lon'].values, ds_out['lon'].values)
 
+    # Allow (but skip) other non spatial variables
+    ds_result2 = regridder(ds_in.assign(nonspatial=ds_in.x * ds_in.time))
+    xr.testing.assert_identical(ds_result2, ds_result)
+
 
 def test_regrid_dataset_to_locstream():
     # xarray.Dataset containing in-memory numpy array


### PR DESCRIPTION
When regridding datasets directly, any data variable that doesn't have the regridded dimensions will make the `apply_ufunc` call fail. In my experience, I often find things like "time_bnds" or "rotated_pole" as data variables. 
The workarounds are easy : either drop the culprits, set them as coords or regrid the dataarrays in a loop.

However, it might be interesting to solve this directly in xESMF? Simply yet-another-workaround avoided for the end user. I suggest this easy solution where variables not containing the regridded dimensions are simply skipped.