### PR TITLE
locstream dim name consistent with ds_out

### DIFF
--- a/xesmf/frontend.py
+++ b/xesmf/frontend.py
@@ -756,6 +756,8 @@ class Regridder(BaseRegridder):
 
         if self.sequence_out:
             out = out.squeeze(dim='dummy')
+            if self.lon_dim == self.lat_dim:
+                out = out.rename(locations=self.lon_dim)
 
         # Use ds_out coordinates
         out = out.rename(self._coord_names)

--- a/xesmf/tests/test_frontend.py
+++ b/xesmf/tests/test_frontend.py
@@ -577,3 +577,23 @@ def test_non_cf_latlon():
     # Test non-CF lat/lon extraction for both DataArray and Dataset
     xe.Regridder(ds_in_noncf['data'], ds_out, 'bilinear')
     xe.Regridder(ds_in_noncf, ds_out, 'bilinear')
+
+
+@pytest.mark.parametrize(
+    'var_renamer,dim_out',
+    [
+        ({}, 'locations'),
+        ({'lon': {'locations': 'foo'}, 'lat': {'locations': 'foo'}}, 'foo'),
+        ({'lon': {'locations': 'foo'}, 'lat': {'locations': 'bar'}}, 'locations'),
+    ],
+)
+def test_locstream_dim_name(var_renamer, dim_out):
+
+    ds_locs_renamed = ds_locs.copy()
+    for var, renamer in var_renamer.items():
+        ds_locs_renamed[var] = ds_locs_renamed[var].rename(renamer)
+
+    regridder = xe.Regridder(ds_in, ds_locs_renamed, 'bilinear', locstream_out=True)
+    expected = {'lev', 'time', 'x_b', 'y_b', dim_out}
+    actual = set(regridder(ds_in).dims)
+    assert expected == actual


### PR DESCRIPTION
`locations` is currently the hard-coded dimension name given to outputs when using `locstream_out=True`.
This PR uses the same name as `ds_out` when the coordinates have consistent dimension names.
