### PR TITLE
Set add_nans_to_weights as default as discussed in #56

### DIFF
--- a/xesmf/frontend.py
+++ b/xesmf/frontend.py
@@ -274,15 +274,10 @@ class BaseRegridder(object):
             uses the two last dimensions of the object (or the last one for input LocStreams and Meshes).
 
         unmapped_to_nan: boolean, optional
-            Option to select the default value for undefined weights (weights of unmapped cells).
-            If `True`, the value will be set to `np.nan`. If a mask is specified for the target grid,
-            this has the effect to mask the target grid cells accordingly. Additionally, this has the
-            effect to mask target grid cells lying outside of the source domain for all regridding methods
-            but `nearest_s2d` and `nearest_d2s`, where such a distinction is not readily possible.
-            If a mask is specified for the target grid, `unmapped_to_nan` will be set to `True` by default.
-            Else the default is `False`, causing weight matrix entries of unmapped cells to be zero, which
-            is also the default behaviour of ESMF.
-
+            Set values of unmapped points to `np.nan` instead of zero (ESMF default). This is useful for
+            target cells lying outside of the source domain when no output mask is defined.
+            If an output mask is defined, or regridding method is `nearest_s2d` or `nearest_d2s`,
+            this option has no effect.
 
         Returns
         -------
@@ -733,14 +728,10 @@ class Regridder(BaseRegridder):
             (i.e. triangles or lines, instead of quadrilaterals)
 
         unmapped_to_nan: boolean, optional
-            Option to select the default value for undefined weights (weights of unmapped cells).
-            If `True`, the value will be set to `np.nan`. If a mask is specified for the target grid,
-            this has the effect to mask the target grid cells accordingly. Additionally, this has the
-            effect to mask target grid cells lying outside of the source domain for all regridding methods
-            but `nearest_s2d` and `nearest_d2s`, where such a distinction is not readily possible.
-            If a mask is specified for the target grid, `unmapped_to_nan` will be set to `True` by default.
-            Else the default is `False`, causing weight matrix entries of unmapped cells to be zero, which
-            is also the default behaviour of ESMF.
+            Set values of unmapped points to `np.nan` instead of zero (ESMF default). This is useful for
+            target cells lying outside of the source domain when no output mask is defined.
+            If an output mask is defined, or regridding method is `nearest_s2d` or `nearest_d2s`,
+            this option has no effect.
 
         Returns
         -------

--- a/xesmf/frontend.py
+++ b/xesmf/frontend.py
@@ -320,7 +320,10 @@ class BaseRegridder(object):
         self.weights = read_weights(weights, self.n_in, self.n_out)
 
         # replace zeros by NaN in mask
-        if apply_add_nans_to_weights == True and self.method not in ['nearest_s2d', 'nearest_d2s']:
+        if (apply_add_nans_to_weights == True and
+            (self.method not in ['nearest_s2d', 'nearest_d2s'] or
+             (self.grid_out.mask is not None and
+              self.grid_out.mask[0] is not None))):
             self.weights = add_nans_to_weights(self.weights)
 
         # follows legacy logic of writing weights if filename is provided

--- a/xesmf/frontend.py
+++ b/xesmf/frontend.py
@@ -327,7 +327,9 @@ class BaseRegridder(object):
         self.weights = read_weights(weights, self.n_in, self.n_out)
 
         # replace zeros by NaN for weight matrix entries of unmapped target cells if specified or a mask is present
-        if ((self.grid_out.mask is not None) and (self.grid_out.mask[0] is not None)) or unmapped_to_nan is True:
+        if (
+            (self.grid_out.mask is not None) and (self.grid_out.mask[0] is not None)
+        ) or unmapped_to_nan is True:
             self.weights = add_nans_to_weights(self.weights)
 
         # follows legacy logic of writing weights if filename is provided

--- a/xesmf/frontend.py
+++ b/xesmf/frontend.py
@@ -207,6 +207,7 @@ class BaseRegridder(object):
         weights=None,
         ignore_degenerate=None,
         input_dims=None,
+        apply_add_nans_to_weights=True,
     ):
         """
         Base xESMF regridding class supporting ESMF objects: `Grid`, `Mesh` and `LocStream`.
@@ -271,6 +272,11 @@ class BaseRegridder(object):
             If not given or if those are not found on the regridded object, regridding
             uses the two last dimensions of the object (or the last one for input LocStreams and Meshes).
 
+        apply_add_nans_to_weights: boolean, optional
+            If True (default), for other than the 'nearest_*' regridding methods, will execute
+            'add_nans_to_weights' to propagate empty weights as NaNs instead of zeros.
+            Target grid cells lying outside of the source domain will then be masked.
+
         Returns
         -------
         baseregridder : xESMF BaseRegridder object
@@ -314,7 +320,7 @@ class BaseRegridder(object):
         self.weights = read_weights(weights, self.n_in, self.n_out)
 
         # replace zeros by NaN in mask
-        if self.grid_out.mask is not None and self.grid_out.mask[0] is not None:
+        if apply_add_nans_to_weights == True and self.method not in ['nearest_s2d', 'nearest_d2s']:
             self.weights = add_nans_to_weights(self.weights)
 
         # follows legacy logic of writing weights if filename is provided
@@ -668,6 +674,11 @@ class Regridder(BaseRegridder):
             If False (default), raise error if grids contain degenerated cells
             (i.e. triangles or lines, instead of quadrilaterals)
 
+        apply_add_nans_to_weights: boolean, optional
+            If True (default), for other than the 'nearest_*' regridding methods, will execute
+            'add_nans_to_weights' to propagate empty weights as NaNs instead of zeros.
+            Target grid cells lying outside of the source domain will then be masked.
+
         Returns
         -------
         regridder : xESMF regridder object
@@ -885,6 +896,7 @@ class SpatialAverager(BaseRegridder):
             filename=filename,
             reuse_weights=reuse_weights,
             ignore_degenerate=ignore_degenerate,
+            apply_add_nans_to_weights=False,
         )
 
     def _compute_weights(self):
@@ -899,12 +911,20 @@ class SpatialAverager(BaseRegridder):
         # Get weights for single polygons and holes
         # Stack everything together
         reg_ext = BaseRegridder(
-            mesh_ext, self.grid_in, 'conservative', ignore_degenerate=self.ignore_degenerate
+            mesh_ext,
+            self.grid_in,
+            'conservative',
+            ignore_degenerate=self.ignore_degenerate,
+            apply_add_nans_to_weights=False
         )
         if len(holes) > 0 and not self.ignore_holes:
             mesh_holes, shape_holes = polys_to_ESMFmesh(holes)
             reg_holes = BaseRegridder(
-                mesh_holes, self.grid_in, 'conservative', ignore_degenerate=self.ignore_degenerate
+                mesh_holes,
+                self.grid_in,
+                'conservative',
+                ignore_degenerate=self.ignore_degenerate,
+                apply_add_nans_to_weights=False
             )
             w_all = sps.hstack((reg_ext.weights.tocsc(), -reg_holes.weights.tocsc()))
         else:

--- a/xesmf/frontend.py
+++ b/xesmf/frontend.py
@@ -207,7 +207,7 @@ class BaseRegridder(object):
         weights=None,
         ignore_degenerate=None,
         input_dims=None,
-        default_weights=True,
+        default_weights=False,
     ):
         """
         Base xESMF regridding class supporting ESMF objects: `Grid`, `Mesh` and `LocStream`.
@@ -273,11 +273,12 @@ class BaseRegridder(object):
             uses the two last dimensions of the object (or the last one for input LocStreams and Meshes).
 
         default_weights: boolean, optional
-            Option to select the default value for undefined weights. If True (default), the value will be set to `np.nan`.
+            Option to select the default value for undefined weights. If `True`, the value will be set to `np.nan`.
             If a mask is specified for the target grid, this has the effect to mask the target grid cells accordingly.
             Additionally, this has the effect to mask target grid cells lying outside of the source domain ("unmapped cells")
             for all regridding methods but `nearest_s2d` and `nearest_d2s`, where such a distinction is not readily possible.
-            If set to False, the default value for undefined weights will be zero, which is the default behaviour of ESMF.
+            If set to `False` (current default), the default value for undefined weights will be zero, which is the default
+            behaviour of ESMF. `True` will become the default setting in future releases.
 
         Returns
         -------
@@ -324,6 +325,16 @@ class BaseRegridder(object):
         # replace zeros by NaN in mask
         if default_weights is True:
             self.weights = add_nans_to_weights(self.weights)
+
+        # Warning to be removed when the default value changes in future releases
+        message = (
+            'The default value of the parameter \'default_weights\' will be set to True in future releases.'
+            ' This option is used to select the default value for undefined weights.'
+            ' If True, undefined entries of the weight matrix will be set to np.nan.'
+            ' If False, undefined weights will be set to zero.'
+            ' The SpatialAverager will not be affected by this setting.'
+        )
+        warnings.warn(message, FutureWarning)
 
         # follows legacy logic of writing weights if filename is provided
         if filename is not None and not reuse_weights:
@@ -677,11 +688,12 @@ class Regridder(BaseRegridder):
             (i.e. triangles or lines, instead of quadrilaterals)
 
         default_weights: boolean, optional
-            Option to select the default value for undefined weights. If True (default), the value will be set to `np.nan`.
+            Option to select the default value for undefined weights. If `True`, the value will be set to `np.nan`.
             If a mask is specified for the target grid, this has the effect to mask the target grid cells accordingly.
             Additionally, this has the effect to mask target grid cells lying outside of the source domain ("unmapped cells")
             for all regridding methods but `nearest_s2d` and `nearest_d2s`, where such a distinction is not readily possible.
-            If set to False, the default value for undefined weights will be zero, which is the default behaviour of ESMF.
+            If set to `False` (current default), the default value for undefined weights will be zero, which is the default
+            behaviour of ESMF. `True` will become the default setting in future releases.
 
         Returns
         -------

--- a/xesmf/tests/test_frontend.py
+++ b/xesmf/tests/test_frontend.py
@@ -105,22 +105,33 @@ methods_list = ['bilinear', 'conservative', 'nearest_s2d', 'nearest_d2s']
 
 
 @pytest.mark.parametrize(
-    'locstream_in,locstream_out,method',
+    'locstream_in,locstream_out,method,unmapped_to_nan',
     [
-        (False, False, 'conservative'),
-        (False, False, 'bilinear'),
-        (False, True, 'bilinear'),
-        (False, False, 'nearest_s2d'),
-        (False, True, 'nearest_s2d'),
-        (True, False, 'nearest_s2d'),
-        (True, True, 'nearest_s2d'),
-        (False, False, 'nearest_d2s'),
-        (False, True, 'nearest_d2s'),
-        (True, False, 'nearest_d2s'),
-        (True, True, 'nearest_d2s'),
+        (False, False, 'conservative', False),
+        (False, False, 'bilinear', False),
+        (False, True, 'bilinear', False),
+        (False, False, 'nearest_s2d', False),
+        (False, True, 'nearest_s2d', False),
+        (True, False, 'nearest_s2d', False),
+        (True, True, 'nearest_s2d', False),
+        (False, False, 'nearest_d2s', False),
+        (False, True, 'nearest_d2s', False),
+        (True, False, 'nearest_d2s', False),
+        (True, True, 'nearest_d2s', False),
+        (False, False, 'conservative', True),
+        (False, False, 'bilinear', True),
+        (False, True, 'bilinear', True),
+        (False, False, 'nearest_s2d', True),
+        (False, True, 'nearest_s2d', True),
+        (True, False, 'nearest_s2d', True),
+        (True, True, 'nearest_s2d', True),
+        (False, False, 'nearest_d2s', True),
+        (False, True, 'nearest_d2s', True),
+        (True, False, 'nearest_d2s', True),
+        (True, True, 'nearest_d2s', True),
     ],
 )
-def test_build_regridder(method, locstream_in, locstream_out):
+def test_build_regridder(method, locstream_in, locstream_out, unmapped_to_nan):
     din = ds_locs if locstream_in else ds_in
     dout = ds_locs if locstream_out else ds_out
 
@@ -174,7 +185,7 @@ def test_to_netcdf(tmp_path):
     # Let the frontend write the weights to disk
     xfn = tmp_path / 'ESMF_weights.nc'
     method = 'bilinear'
-    regridder = xe.Regridder(ds_in, ds_out, method, default_weights=False)
+    regridder = xe.Regridder(ds_in, ds_out, method, unmapped_to_nan=False)
     regridder.to_netcdf(filename=xfn)
 
     grid_in = Grid.from_xarray(ds_in['lon'].values.T, ds_in['lat'].values.T)
@@ -195,7 +206,7 @@ def test_to_netcdf_nans(tmp_path):
     # Let the frontend write the weights to disk
     xfn = tmp_path / 'ESMF_weights_nans.nc'
     method = 'bilinear'
-    regridder = xe.Regridder(ds_in, ds_out, method, default_weights=True)
+    regridder = xe.Regridder(ds_in, ds_out, method, unmapped_to_nan=True)
     regridder.to_netcdf(filename=xfn)
 
     grid_in = Grid.from_xarray(ds_in['lon'].values.T, ds_in['lat'].values.T)
@@ -238,7 +249,7 @@ def test_build_regridder_from_dict():
 
 def test_regrid_periodic_wrong():
     # not using periodic option
-    regridder = xe.Regridder(ds_in, ds_out, 'bilinear', default_weights=False)
+    regridder = xe.Regridder(ds_in, ds_out, 'bilinear', unmapped_to_nan=False)
 
     dr_out = regridder(ds_in['data'])  # xarray DataArray
 

--- a/xesmf/tests/test_frontend.py
+++ b/xesmf/tests/test_frontend.py
@@ -195,7 +195,7 @@ def test_to_netcdf_nans(tmp_path):
     # Let the frontend write the weights to disk
     xfn = tmp_path / 'ESMF_weights_nans.nc'
     method = 'bilinear'
-    regridder = xe.Regridder(ds_in, ds_out, method)
+    regridder = xe.Regridder(ds_in, ds_out, method, default_weights=True)
     regridder.to_netcdf(filename=xfn)
 
     grid_in = Grid.from_xarray(ds_in['lon'].values.T, ds_in['lat'].values.T)


### PR DESCRIPTION
BaseRegridder: Applying weight modification add_nans_to_weights as default for all but nearest neighbour regridding methods. Fixes #56 

- Instead of being applied only in presence of an output mask, `add_nans_to_weights` will now be applied by default
  during the BaseRegridder initialization for all but the nearest neighbour regridding methods (nearest_s2d,
  nearest_d2s).
- The default parameter "apply_add_nans_to_weights = True" has been added to `BaseRegridder.__init__()`,
  causing above behaviour.
- The `SpatialAverager` class has been modified to include the parameter `apply_add_nans_to_weights = False`
  when initializing BaseRegridder / Regridder to preserve its original behaviour.
- Added in tests/test_frontend: `test_to_netcdf_nans`
- Modified in tests/test_frontend: `test_to_netcdf`, `test_regrid_periodic_wrong`
  Added parameter `apply_add_nans_to_weights = False` when initializing `Regridder`,
  to preserve the original behaviour/purpose of the test.

Any feedback is welcome :)