### PR TITLE
FutureWarning in apply_ufunc

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ if on_rtd:
 else:
     INSTALL_REQUIRES = [
         'esmpy>=8.0.0',
-        'xarray!=0.16.1',
+        'xarray>=0.16.2',
         'numpy>=1.16',
         'scipy',
         'shapely',

--- a/xesmf/frontend.py
+++ b/xesmf/frontend.py
@@ -527,9 +527,11 @@ class BaseRegridder(object):
             output_core_dims=[temp_horiz_dims],
             dask='parallelized',
             output_dtypes=[float],
-            output_sizes={
-                temp_horiz_dims[0]: self.shape_out[0],
-                temp_horiz_dims[1]: self.shape_out[1],
+            dask_gufunc_kwargs={
+                'output_sizes': {
+                    temp_horiz_dims[0]: self.shape_out[0],
+                    temp_horiz_dims[1]: self.shape_out[1],
+                },
             },
             keep_attrs=keep_attrs,
         )
@@ -560,9 +562,11 @@ class BaseRegridder(object):
             output_core_dims=[temp_horiz_dims],
             dask='parallelized',
             output_dtypes=[float],
-            output_sizes={
-                temp_horiz_dims[0]: self.shape_out[0],
-                temp_horiz_dims[1]: self.shape_out[1],
+            dask_gufunc_kwargs={
+                'output_sizes': {
+                    temp_horiz_dims[0]: self.shape_out[0],
+                    temp_horiz_dims[1]: self.shape_out[1],
+                },
             },
             keep_attrs=keep_attrs,
         )


### PR DESCRIPTION
Since https://github.com/pydata/xarray/pull/4060, xesmf has given a FutureWarning for supplying `output_sizes` directly in `xr.apply_ufunc` rather than through `dask_gufunc_kwargs`.

```python
import xarray as xr
import xesmf as xe

ds = xr.tutorial.open_dataset('air_temperature')
regridder = xe.Regridder(ds, ds[['lon', 'lat']], 'bilinear')
regridder(ds)
```
```
xesmf/frontend.py:555: FutureWarning: ``output_sizes`` should be given in the ``dask_gufunc_kwargs`` parameter. It will be removed as direct parameter in a future version.
  ds_out = xr.apply_ufunc(
```

This eliminates the warning.