### PR TITLE
fix ci linter by adding toml to envs

### DIFF
--- a/ci/environment-upstream-dev.yml
+++ b/ci/environment-upstream-dev.yml
@@ -13,6 +13,7 @@ dependencies:
   - pytest
   - pytest-cov
   - scipy
+  - toml
   - pip:
       - git+https://github.com/pydata/xarray.git
       - git+https://github.com/xarray-contrib/cf-xarray.git

--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -15,4 +15,5 @@ dependencies:
   - pytest-cov
   - scipy
   - shapely
+  - toml
   - xarray


### PR DESCRIPTION
pending PRs fail on linting in CI, fixes dependency to `toml` in github workflow