### PR TITLE
On-the-fly endianness conversion

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,7 @@ What's new
 
 Bug fixes
 ~~~~~~~~~
-- The introduction of `sparse`, with `numba` under the hood, restricted input data to little-endian dtypes. On-the-fly endianness conversion fixes that problem, but performances might be affected (:pull:`125`). By `Pascal Bourgault <https://github.com/aulemahal>`_
+- The introduction of `sparse`, with `numba` under the hood, restricted input data to little-endian dtypes. In those cases, xESMF switches back to using scipy (:pull:`125`). By `Pascal Bourgault <https://github.com/aulemahal>`_
 
 0.6.1 (23-09-2021)
 ------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,13 @@
 What's new
 ==========
 
+0.6.2 (unreleased)
+------------------
+
+Bug fixes
+~~~~~~~~~
+- The introduction of `sparse`, with `numba` under the hood, restricted input data to little-endian dtypes. On-the-fly endianness conversion fixes that problem, but performances might be affected (:pull:`125`). By `Pascal Bourgault <https://github.com/aulemahal>`_
+
 0.6.1 (23-09-2021)
 ------------------
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,7 +8,7 @@ extend-ignore = E203,E501,E402,W605
 
 [isort]
 known_first_party=xesmf
-known_third_party=ESMF,cf_xarray,cftime,dask,numpy,pytest,setuptools,shapely,sparse,xarray
+known_third_party=ESMF,cf_xarray,cftime,dask,numba,numpy,pytest,setuptools,shapely,sparse,xarray
 multi_line_output=3
 include_trailing_comma=True
 force_grid_wrap=0

--- a/xesmf/smm.py
+++ b/xesmf/smm.py
@@ -125,11 +125,12 @@ def apply_weights(weights, indata, shape_in, shape_out):
     # Limitation from numba : some big-endian dtypes are not supported.
     try:
         nb.from_dtype(indata.dtype)
+        nb.from_dtype(weights.dtype)
     except NotImplementedError:
         warnings.warn(
-            'Input array has a dtype not supported by numba. Recasting might affest performance.'
+            'Input array has a dtype not supported by sparse and numba. Falling back to scipy.'
         )
-        indata = indata.astype(indata.dtype.newbyteorder())
+        weights = weights.to_scipy_sparse()
 
     # COO matrix is fast with F-ordered array but slow with C-array, so we
     # take in a C-ordered and then transpose)

--- a/xesmf/smm.py
+++ b/xesmf/smm.py
@@ -126,7 +126,9 @@ def apply_weights(weights, indata, shape_in, shape_out):
     try:
         nb.from_dtype(indata.dtype)
     except NotImplementedError:
-        warnings.warn('Input array has a dtype not supported by numba. Recasting might affest performance.')
+        warnings.warn(
+            'Input array has a dtype not supported by numba. Recasting might affest performance.'
+        )
         indata = indata.astype(indata.dtype.newbyteorder())
 
     # COO matrix is fast with F-ordered array but slow with C-array, so we

--- a/xesmf/smm.py
+++ b/xesmf/smm.py
@@ -5,6 +5,7 @@ Sparse matrix multiplication (SMM) using scipy.sparse library.
 import warnings
 from pathlib import Path
 
+import numba as nb
 import numpy as np
 import sparse as sps
 import xarray as xr
@@ -121,6 +122,12 @@ def apply_weights(weights, indata, shape_in, shape_out):
         Extra dimensions are the same as `indata`.
         If input data is C-ordered, output will also be C-ordered.
     """
+    # Limitation from numba : some big-endian dtypes are not supported.
+    try:
+        nb.from_dtype(indata.dtype)
+    except NotImplementedError:
+        warnings.warn('Input array has a dtype not supported by numba. Recasting might affest performance.')
+        indata = indata.astype(indata.dtype.newbyteorder())
 
     # COO matrix is fast with F-ordered array but slow with C-array, so we
     # take in a C-ordered and then transpose)

--- a/xesmf/tests/test_frontend.py
+++ b/xesmf/tests/test_frontend.py
@@ -402,6 +402,19 @@ def test_regrid_dataarray(use_cfxr):
         xr.testing.assert_identical(dr_out, dr_out_rn)
 
 
+def test_regrid_dataarray_endianess():
+    # xarray.DataArray containing in-memory numpy array
+    regridder = xe.Regridder(ds_in, ds_out, 'conservative')
+
+    exp = regridder(ds_in['data'])  # Normal (little-endian)
+    with pytest.warns(UserWarning, match="Input array has a dtype not supported"):
+        out = regridder(ds_in['data'].astype('>f8'))  # big endian
+
+    # Results should be the same
+    assert_equal(exp.values, out.values)
+    assert exp.dtype == out.dtype
+
+
 def test_regrid_dataarray_to_locstream():
     # xarray.DataArray containing in-memory numpy array
 

--- a/xesmf/tests/test_frontend.py
+++ b/xesmf/tests/test_frontend.py
@@ -407,7 +407,7 @@ def test_regrid_dataarray_endianess():
     regridder = xe.Regridder(ds_in, ds_out, 'conservative')
 
     exp = regridder(ds_in['data'])  # Normal (little-endian)
-    with pytest.warns(UserWarning, match="Input array has a dtype not supported"):
+    with pytest.warns(UserWarning, match='Input array has a dtype not supported'):
         out = regridder(ds_in['data'].astype('>f8'))  # big endian
 
     # Results should be the same

--- a/xesmf/tests/test_frontend.py
+++ b/xesmf/tests/test_frontend.py
@@ -412,7 +412,7 @@ def test_regrid_dataarray_endianess():
 
     # Results should be the same
     assert_equal(exp.values, out.values)
-    assert exp.dtype == out.dtype
+    assert out.dtype == '>f8'
 
 
 def test_regrid_dataarray_to_locstream():


### PR DESCRIPTION
Fixes #124.

#111 introduced an unforeseen constrain : machine architectures and data dtypes are now restricted by what `numba` supports. `numba` is used by `sparse` under the hood. I have not heard of problems with machine architectures, but issue #124 is due to data coming from a different computer that uses "big-endian" (numpy's ">f8" dtype).

~This introduces on-the-fly byte-swapping, to convert to little-endian. The performance cost is unmeasured, but should be quite low. I find it a bit ugly to perform that conversion in xESMF instead of `sparse` directly, but this is the fastest solution I could think of.~
EDIT: Instead of converting dtypes on-the-fly, I converted the weights from it's `sparse` format to a `scipy` matrix, which doesn't use numba and thus resolves the problem. It also conserves the dtype, which might be wanted.

I used a function from `numba` directly, should I add it as an explicit dependency?

Also, it might not be necessary to raise a warning?