### PR TITLE
Fix SpatialAverager to account for variable input grid cells areas

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,14 @@
 What's new
 ==========
 
+0.6.2 (unreleased)
+------------------
+
+Bug fixes
+~~~~~~~~~
+- SpatialAverager did not compute the same weights as Regridder when source cell areas were not uniform (:pull:`128`). By `David Huard <https://github.com/huard>`_
+
+
 0.6.1 (23-09-2021)
 ------------------
 

--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -6,13 +6,13 @@ dependencies:
   - cftime
   - codecov
   - dask
-  - esmpy
+  - esmpy<8.2.0
   - numpy
   - pip
   - pre-commit
   - pydap
   - pytest
   - pytest-cov
-  - shapely
+  - shapely<=1.7
   - sparse
   - xarray>=0.17.0

--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -6,13 +6,13 @@ dependencies:
   - cftime
   - codecov
   - dask
-  - esmpy<8.2.0
+  - esmpy
   - numpy
   - pip
   - pre-commit
   - pydap
   - pytest
   - pytest-cov
-  - shapely<=1.7
+  - shapely
   - sparse
   - xarray>=0.17.0

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -58,7 +58,7 @@ autodoc_member_order = 'bysource'
 
 # To avoid installing xESMF and all its dependencies when building doc
 # https://stackoverflow.com/a/15912502/8729698
-autodoc_mock_imports = ['numpy', 'xarray', 'scipy', 'ESMF', 'dask']
+autodoc_mock_imports = ['numpy', 'xarray', 'scipy', 'ESMF', 'dask', 'sparse']
 
 # avoid automatic execution for notebooks
 nbsphinx_execute = 'never'

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -58,7 +58,7 @@ autodoc_member_order = 'bysource'
 
 # To avoid installing xESMF and all its dependencies when building doc
 # https://stackoverflow.com/a/15912502/8729698
-autodoc_mock_imports = ['numpy', 'xarray', 'scipy', 'ESMF', 'dask', 'sparse']
+autodoc_mock_imports = ['numpy', 'xarray', 'scipy', 'ESMF', 'dask', 'sparse', 'numba']
 
 # avoid automatic execution for notebooks
 nbsphinx_execute = 'never'

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -7,3 +7,4 @@ nbsphinx
 sphinx
 sphinx_rtd_theme
 cf_xarray
+docutils!=0.18

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -7,4 +7,3 @@ nbsphinx
 sphinx==3.2.1
 sphinx_rtd_theme
 cf_xarray
-sparse

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -7,3 +7,4 @@ nbsphinx
 sphinx==3.2.1
 sphinx_rtd_theme
 cf_xarray
+sparse

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -4,6 +4,6 @@ descartes
 ipython
 Pygments>=2.6
 nbsphinx
-sphinx==3.2.1
+sphinx
 sphinx_rtd_theme
 cf_xarray

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,8 +1,10 @@
 build:
   image: latest
 
-python:
-  version: 3.6
-  setup_py_install: true
+version: 2
 
-requirements_file: doc/requirements.txt
+python:
+  install:
+    - requirements: doc/requirements.txt
+    - method: pip
+      path: .

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ else:
         'esmpy>=8.0.0',
         'xarray>=0.16.2',
         'numpy>=1.16',
-        'shapely',
+        'shapely < 1.8',
         'cf-xarray>=0.5.1',
         'sparse',
     ]

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ else:
         'esmpy>=8.0.0',
         'xarray>=0.16.2',
         'numpy>=1.16',
-        'shapely < 1.8',
+        'shapely<=1.7',
         'cf-xarray>=0.5.1',
         'sparse',
     ]

--- a/xesmf/backend.py
+++ b/xesmf/backend.py
@@ -250,7 +250,7 @@ class Mesh(ESMF.Mesh):
         """
         node_num = sum(e.exterior.coords.array_interface()['shape'][0] - 1 for e in polys)
         elem_num = len(polys)
-        # Pre alloc arrays. Special stucture for coords makes the code faster.
+        # Pre alloc arrays. Special structure for coords makes the code faster.
         crd_dt = np.dtype([('x', np.float32), ('y', np.float32)])
         node_coords = np.empty(node_num, dtype=crd_dt)
         node_coords[:] = (np.nan, np.nan)  # Fill with impossible values

--- a/xesmf/data.py
+++ b/xesmf/data.py
@@ -6,7 +6,7 @@ import numpy as np
 
 
 def wave_smooth(lon, lat):
-    """
+    r"""
     Spherical harmonic with low frequency.
 
     Parameters

--- a/xesmf/frontend.py
+++ b/xesmf/frontend.py
@@ -984,9 +984,7 @@ class SpatialAverager(BaseRegridder):
 
         # Get the weights and convert to a DataArray
         weights = regrid.get_weights_dict(deep_copy=True)
-        shape_out = mesh_out.get_shape()[::-1]
-        n_out = shape_out[0] * shape_out[1]
-        w = _parse_coords_and_values(weights, self.n_in, n_out)
+        w = _parse_coords_and_values(weights, self.n_in, mesh_out.element_count)
 
         # Get destination area - important for renormalizing the subgeometries.
         regrid.dstfield.get_area()

--- a/xesmf/frontend.py
+++ b/xesmf/frontend.py
@@ -883,7 +883,7 @@ class SpatialAverager(BaseRegridder):
             Shape of bounds should be (n+1,) or (n_y+1, n_x+1).
 
         polys : sequence of shapely Polygons and MultiPolygons
-            Sequence of polygons over which to average `ds_in`.
+            Sequence of polygons (lon, lat) over which to average `ds_in`.
 
         ignore_holes : bool
             Whether to ignore holes in polygons.

--- a/xesmf/frontend.py
+++ b/xesmf/frontend.py
@@ -736,6 +736,7 @@ class Regridder(BaseRegridder):
               - a dictionary with keys `row_dst`, `col_src` and `weights`,
               - an xarray Dataset with data variables `col`, `row` and `S`,
               - or a path to a netCDF file created by ESMF.
+
             If None, compute the weights.
 
         ignore_degenerate : bool, optional
@@ -911,6 +912,7 @@ class SpatialAverager(BaseRegridder):
               - a dictionary with keys `row_dst`, `col_src` and `weights`,
               - an xarray Dataset with data variables `col`, `row` and `S`,
               - or a path to a netCDF file created by ESMF.
+
             If None, compute the weights.
 
         ignore_degenerate : bool, optional

--- a/xesmf/frontend.py
+++ b/xesmf/frontend.py
@@ -6,12 +6,17 @@ import warnings
 
 import cf_xarray as cfxr
 import numpy as np
-import sparse as sps
 import xarray as xr
 from xarray import DataArray, Dataset
 
 from .backend import Grid, LocStream, Mesh, add_corner, esmf_regrid_build, esmf_regrid_finalize
-from .smm import _combine_weight_multipoly, add_nans_to_weights, apply_weights, read_weights
+from .smm import (
+    _combine_weight_multipoly,
+    _parse_coords_and_values,
+    add_nans_to_weights,
+    apply_weights,
+    read_weights,
+)
 from .util import split_polygons_and_holes
 
 try:
@@ -887,7 +892,7 @@ class SpatialAverager(BaseRegridder):
 
         ignore_holes : bool
             Whether to ignore holes in polygons.
-            Default (True) is to substract the weight of holes from the weight of the polygon.
+            Default (True) is to subtract the weight of holes from the weight of the polygon.
 
         filename : str, optional
             Name for the weight file. The default naming scheme is::
@@ -925,6 +930,7 @@ class SpatialAverager(BaseRegridder):
         ----------
         This approach is inspired by `OCGIS <https://github.com/NCPP/ocgis>`_.
         """
+        # Note, I suggest we refactor polys -> geoms
         self.ignore_holes = ignore_holes
         self.polys = polys
         self.geom_dim_name = geom_dim_name
@@ -963,51 +969,73 @@ class SpatialAverager(BaseRegridder):
             unmapped_to_nan=False,
         )
 
-    def _compute_weights(self):
-        """Return weight sparse matrix."""
+    def _compute_weights_and_area(self, mesh_out):
+        """Return the weights and the area of the destination mesh cells."""
 
-        # Split all (multi-)polygons into single polygons and holes. Keep track of owners.
-        exts, holes, i_ext, i_hol = split_polygons_and_holes(self.polys)
-        owners = np.array(i_ext + i_hol)
-
-        mesh_ext, shape_ext = polys_to_ESMFmesh(exts)
-
-        # Get weights for single polygons and holes
-        # Stack everything together
-        reg_ext = BaseRegridder(
-            mesh_ext,
+        # Build the regrid object
+        regrid = esmf_regrid_build(
             self.grid_in,
-            'conservative',
+            mesh_out,
+            method='conservative',
             ignore_degenerate=self.ignore_degenerate,
-            unmapped_to_nan=False,
         )
-        if len(holes) > 0 and not self.ignore_holes:
-            mesh_holes, shape_holes = polys_to_ESMFmesh(holes)
-            reg_holes = BaseRegridder(
-                mesh_holes,
-                self.grid_in,
-                'conservative',
-                ignore_degenerate=self.ignore_degenerate,
-                unmapped_to_nan=False,
-            )
-            w_all = xr.concat((reg_ext.weights, -reg_holes.weights), 'in_dim')
-        else:
-            w_all = reg_ext.weights
 
-        # "Transpose" the data, weights generated before are mesh -> grid, we want grid -> mesh
-        w_all = w_all.rename(in_dim='out_dim', out_dim='in_dim')
+        # Get the weights and convert to a DataArray
+        weights = regrid.get_weights_dict(deep_copy=True)
+        shape_out = mesh_out.get_shape()[::-1]
+        n_out = shape_out[0] * shape_out[1]
+        w = _parse_coords_and_values(weights, self.n_in, n_out)
 
-        # Combine weights of same owner
-        weights = _combine_weight_multipoly(w_all, owners)
-        # Normalize weights
-        wsum = weights.sum('in_dim')
-        # All this only to change the fill_value...
-        wsum = wsum.copy(
-            data=sps.COO(wsum.data.coords, wsum.data.data, shape=wsum.data.shape, fill_value=1)
-        )
-        weights = weights / wsum
-        # Transpose to fit with the rest of xesmf.
-        return weights.transpose('out_dim', 'in_dim')
+        # Get destination area - important for renormalizing the subgeometries.
+        regrid.dstfield.get_area()
+        dstarea = regrid.dstfield.data.copy()
+
+        esmf_regrid_finalize(regrid)
+        return w, dstarea
+
+    def _compute_weights(self):
+        """Return weight sparse matrix.
+
+        This function first explodes the geometries into a flat list of Polygon exterior objects:
+          - Polygon -> polygon.exterior
+          - MultiPolygon -> list of polygon.exterior
+
+        and a list of Polygon.interiors (holes).
+
+        Individual meshes are created for the exteriors and the interiors, and their regridding weights computed.
+        We cannot compute the exterior and interior weights at the same time, because the meshes overlap.
+
+        Weights for the subgeometries are then aggregated back to the original geometries. Because exteriors and
+        interiors are computed independently, we need to normalize the weights according to their area.
+        """
+
+        # Explode geometries into a flat list of polygon exteriors and interiors.
+        # Keep track of original geometry index.
+        # The convention used here is to list the exteriors first and then the interiors.
+        exteriors, interiors, i_ext, i_int = split_polygons_and_holes(self.polys)
+        geom_indices = np.array(i_ext + i_int)
+
+        # Create mesh from external polygons (positive contribution)
+        mesh_ext = Mesh.from_polygons(exteriors)
+
+        # Get weights for external polygons
+        w, area = self._compute_weights_and_area(mesh_ext)
+
+        # Get weights for interiors and append them to weights from exteriors as a negative contribution.
+        if len(interiors) > 0 and not self.ignore_holes:
+            mesh_int = Mesh.from_polygons(interiors)
+
+            # Get weights for interiors
+            w_int, area_int = self._compute_weights_and_area(mesh_int)
+
+            # Append weights from holes as negative weights
+            w = xr.concat((w, -w_int), 'out_dim')
+
+            # Append areas
+            area = np.concatenate([area, area_int])
+
+        # Combine weights for all the subgeometries belonging to the same geometry
+        return _combine_weight_multipoly(w, area, geom_indices).T
 
     def _get_default_filename(self):
         # e.g. bilinear_400x600_300x400.nc

--- a/xesmf/tests/test_frontend.py
+++ b/xesmf/tests/test_frontend.py
@@ -653,9 +653,6 @@ def test_compare_weights_from_poly_and_grid():
 
     # Normally, weights should be identical, but this fails
     # np.testing.assert_array_equal(rgrid.weights.data.todense(), rpoly.weights.data.todense())
-    # i = ds.indexes['lon'].get_loc(-55, method='nearest')
-    # j1 = ds.indexes['lat'].get_loc(12, method='nearest')
-    # j2 = ds.indexes['lat'].get_loc(72, method='nearest')
 
     # Visualize the weights
     wg = np.reshape(rgrid.weights.data.todense(), ds.a.T.shape)
@@ -664,11 +661,18 @@ def test_compare_weights_from_poly_and_grid():
     ds['wg'] = (('lat', 'lon'), wg)
     ds['wp'] = (('lat', 'lon'), wp)
 
+    # Figure of weights in two cases
     # fig, (ax1, ax2) = plt.subplots(1, 2)
     # ds.wg.plot(ax=ax1); ds.wp.plot(ax=ax2)
     # ax1.set_title("Regridder weights")
     # ax2.set_title("SpatialAverager weights")
-    # assert ds.wg.isel(lon=i, lat=j1) > ds.wg.isel(lon=i, lat=j2)
+
+    # Check that source area affects weights
+    i = ds.indexes['lon'].get_loc(-55, method='nearest')
+    j1 = ds.indexes['lat'].get_loc(12, method='nearest')
+    j2 = ds.indexes['lat'].get_loc(72, method='nearest')
+    assert ds.wg.isel(lon=i, lat=j1) > ds.wg.isel(lon=i, lat=j2)
+    assert ds.wp.isel(lon=i, lat=j1).data > ds.wp.isel(lon=i, lat=j2).data  # Fails
 
 
 def test_polys_to_ESMFmesh():

--- a/xesmf/tests/test_frontend.py
+++ b/xesmf/tests/test_frontend.py
@@ -163,11 +163,11 @@ def test_existing_weights():
     # make sure we can reuse weights
     assert os.path.exists(fn)
     regridder_reuse = xe.Regridder(ds_in, ds_out, method, weights=fn)
-    assert regridder_reuse.A.shape == regridder.A.shape
+    assert regridder_reuse.weights.shape == regridder.weights.shape
 
     # this should also work with reuse_weights=True
     regridder_reuse = xe.Regridder(ds_in, ds_out, method, reuse_weights=True, weights=fn)
-    assert regridder_reuse.A.shape == regridder.A.shape
+    assert regridder_reuse.weights.shape == regridder.weights.shape
 
     # or can also overwrite it
     xe.Regridder(ds_in, ds_out, method)
@@ -175,7 +175,7 @@ def test_existing_weights():
     # check legacy args still work
     regridder = xe.Regridder(ds_in, ds_out, method, filename='wgts.nc')
     regridder_reuse = xe.Regridder(ds_in, ds_out, method, reuse_weights=True, filename='wgts.nc')
-    assert regridder_reuse.A.shape == regridder.A.shape
+    assert regridder_reuse.weights.shape == regridder.weights.shape
 
     # check fails on non-existent file
     with pytest.raises(OSError):

--- a/xesmf/tests/test_frontend.py
+++ b/xesmf/tests/test_frontend.py
@@ -85,12 +85,12 @@ polys = [
         MultiPolygon(
             [
                 Polygon([[0.25, 1.25], [0.25, 1.75], [0.75, 1.75], [0.75, 1.25]]),
-                Polygon([[1.25, 1.25], [1.25, 1.75], [1.75, 1.75], [1.75, 1.25]]),
+                Polygon([[1, 1], [1, 2], [2, 2], [2, 1]]),
             ]
         ),
-    ],  # Combination of Polygon and MultiPolygon
+    ],  # Combination of Polygon and MultiPolygon with two different areas
 ]
-exps_polys = [1.75, 3, 2.1429, 4, 0, 2.5, [1.75, 3]]
+exps_polys = [1.75, 3, 2.1429, 4, 0, 2.5, [1.75, 3.6]]
 
 
 def test_as_2d_mesh():

--- a/xesmf/util.py
+++ b/xesmf/util.py
@@ -163,7 +163,7 @@ def _flatten_poly_list(polys):
     """Iterator flattening MultiPolygons."""
     for i, poly in enumerate(polys):
         if isinstance(poly, MultiPolygon):
-            for sub_poly in poly:
+            for sub_poly in poly.geoms:
                 yield (i, sub_poly)
         else:
             yield (i, poly)

--- a/xesmf/util.py
+++ b/xesmf/util.py
@@ -72,17 +72,68 @@ def grid_2d(lon0_b, lon1_b, d_lon, lat0_b, lat1_b, d_lat):
     return ds
 
 
-def grid_global(d_lon, d_lat):
+def cf_grid_2d(lon0_b, lon1_b, d_lon, lat0_b, lat1_b, d_lat):
+    """
+    CF compliant 2D rectilinear grid centers and bounds.
+
+    Parameters
+    ----------
+    lon0_b, lon1_b : float
+        Longitude bounds
+
+    d_lon : float
+        Longitude step size, i.e. grid resolution
+
+    lat0_b, lat1_b : float
+        Latitude bounds
+
+    d_lat : float
+        Latitude step size, i.e. grid resolution
+
+    Returns
+    -------
+    ds : xarray.DataSet with coordinate values
+
+    """
+    from cf_xarray import vertices_to_bounds
+
+    lon_1d, lon_b_1d = _grid_1d(lon0_b, lon1_b, d_lon)
+    lat_1d, lat_b_1d = _grid_1d(lat0_b, lat1_b, d_lat)
+
+    ds = xr.Dataset(
+        coords={
+            'lon': (
+                'lon',
+                lon_1d,
+                {'standard_name': 'longitude', 'units': 'degrees_east', 'bounds': 'lon_bounds'},
+            ),
+            'lat': (
+                'lat',
+                lat_1d,
+                {'standard_name': 'latitude', 'units': 'degrees_north', 'bounds': 'lat_bounds'},
+            ),
+        },
+        data_vars={
+            'lon_bounds': vertices_to_bounds(lon_b_1d, ('bound', 'lon')),
+            'lat_bounds': vertices_to_bounds(lat_b_1d, ('bound', 'lat')),
+        },
+    )
+
+    return ds
+
+
+def grid_global(d_lon, d_lat, cf=False):
     """
     Global 2D rectilinear grid centers and bounds
 
     Parameters
     ----------
     d_lon : float
-        Longitude step size, i.e. grid resolution
-
+      Longitude step size, i.e. grid resolution
     d_lat : float
-        Latitude step size, i.e. grid resolution
+      Latitude step size, i.e. grid resolution
+    cf : bool
+      Return a CF compliant grid.
 
     Returns
     -------
@@ -101,6 +152,9 @@ def grid_global(d_lon, d_lat):
             '180 cannot be divided by d_lat = {}, '
             'might not cover the globe uniformally'.format(d_lat)
         )
+
+    if cf:
+        return cf_grid_2d(-180, 180, d_lon, -90, 90, d_lat)
 
     return grid_2d(-180, 180, d_lon, -90, 90, d_lat)
 


### PR DESCRIPTION
Fix #126

The original implementation used to compute the grid weights over
ds_in : polygon mesh
ds_out : source grid
and then rename out_dim and in_dim to in_dim and out_dim. This simplified the code's logic but had the effect of neglecting variations in source grid cell areas. 

The fix sets source and destination to their expected order, but needs to grab the destination field area from the regrid object to perform a necessary renormalization between exteriors and interiors. This required a bit of refactoring which hopefully will clarify what's going on. 

A test was added to make sure weights computed using an output mesh and an output grid are nearly identical.