### PR TITLE
Reduce dask task count, refactor regrid dispatch

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,8 +7,12 @@ What's new
 Bug fixes
 ~~~~~~~~~
 - The introduction of `sparse`, with `numba` under the hood, restricted input data to little-endian dtypes. In those cases, xESMF switches back to using scipy (:pull:`125`). By `Pascal Bourgault <https://github.com/aulemahal>`_
-- Regridding datasets with dask-backed variables is fixed. Dtype of the outputs is changed for this specific case. By `Pascal Bourgault <https://github.com/aulemahal>`_
 - SpatialAverager did not compute the same weights as Regridder when source cell areas were not uniform (:pull:`128`). By `David Huard <https://github.com/huard>`_
+- Refactor of how the regridding is called internally, to fix a bug with dask and sparse (:pull:`135`). By `Pascal Bourgault <https://github.com/aulemahal>`_
+
+Internal changes
+~~~~~~~~~~~~~~~~
+- Deprecation of ``regrid_numpy`` and ``regrid_dask`` is scheduled for 0.7.0. All checks on shape, array layout and numba support are now done at call time, rather then at computation time (:pull:`135`).
 
 0.6.1 (23-09-2021)
 ------------------

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,7 +8,7 @@ extend-ignore = E203,E501,E402,W605
 
 [isort]
 known_first_party=xesmf
-known_third_party=ESMF,cf_xarray,cftime,dask,numpy,pytest,setuptools,shapely,sparse,xarray
+known_third_party=ESMF,cf_xarray,cftime,dask,numba,numpy,pytest,setuptools,shapely,sparse,xarray
 multi_line_output=3
 include_trailing_comma=True
 force_grid_wrap=0

--- a/xesmf/frontend.py
+++ b/xesmf/frontend.py
@@ -507,14 +507,26 @@ class BaseRegridder(object):
                 weights,
                 dtype=indata.dtype,
                 chunks=output_chunks,
-                # drop_axis=[],
-                # new_axis=[-2, -1],
                 meta=np.array((), dtype=indata.dtype),
                 **kwargs,
             )
         else:  # numpy
             outdata = self._regrid(indata, weights, **kwargs)
         return outdata
+
+    def regrid_numpy(self, indata, **kwargs):
+        warnings.warn(
+            '`regrid_numpy()` will be removed in xESMF 0.7, please use `regrid_array` instead.',
+            category=FutureWarning,
+        )
+        return self.regrid_array(indata, self.weights.data, **kwargs)
+
+    def regrid_dask(self, indata, **kwargs):
+        warnings.warn(
+            '`regrid_dask()` will be removed in xESMF 0.7, please use `regrid_array` instead.',
+            category=FutureWarning,
+        )
+        return self.regrid_array(indata, self.weights.data, **kwargs)
 
     def regrid_dataarray(self, dr_in, keep_attrs=False, skipna=False, na_thres=1.0):
         """See __call__()."""

--- a/xesmf/frontend.py
+++ b/xesmf/frontend.py
@@ -492,7 +492,7 @@ class BaseRegridder(object):
             'shape_out': self.shape_out,
         }
 
-        check_shapes(indata.shape, weights.shape, **kwargs)
+        check_shapes(indata, weights, **kwargs)
 
         kwargs.update(skipna=skipna, na_thres=na_thres)
 

--- a/xesmf/frontend.py
+++ b/xesmf/frontend.py
@@ -469,7 +469,7 @@ class BaseRegridder(object):
             mod = np
 
         if sequence_in:
-            indata = np.expand_dims(indata, axis=-2)
+            indata = mod.reshape(indata, (*indata.shape[:-1], 1, indata.shape[-1]))
 
         # skipna: set missing values to zero
         if skipna:
@@ -537,13 +537,6 @@ class BaseRegridder(object):
             input_core_dims=[input_horiz_dims, ('out_dim', 'in_dim')],
             output_core_dims=[temp_horiz_dims],
             dask='allowed',
-            output_dtypes=[dr_in.dtype],
-            # dask_gufunc_kwargs={
-            #     'output_sizes': {
-            #         temp_horiz_dims[0]: self.shape_out[0],
-            #         temp_horiz_dims[1]: self.shape_out[1],
-            #     },
-            # },
             keep_attrs=keep_attrs,
         )
 
@@ -565,8 +558,6 @@ class BaseRegridder(object):
         ]
         ds_in = ds_in.drop_vars(non_regriddable)
 
-        ds_dtypes = [d.dtype for d in ds_in.data_vars.values()]
-
         ds_out = xr.apply_ufunc(
             self._regrid_array,
             ds_in,
@@ -574,14 +565,7 @@ class BaseRegridder(object):
             kwargs=kwargs,
             input_core_dims=[input_horiz_dims, ('out_dim', 'in_dim')],
             output_core_dims=[temp_horiz_dims],
-            dask='parallelized',
-            output_dtypes=ds_dtypes,
-            dask_gufunc_kwargs={
-                'output_sizes': {
-                    temp_horiz_dims[0]: self.shape_out[0],
-                    temp_horiz_dims[1]: self.shape_out[1],
-                },
-            },
+            dask='allowed',
             keep_attrs=keep_attrs,
         )
 

--- a/xesmf/frontend.py
+++ b/xesmf/frontend.py
@@ -25,7 +25,6 @@ try:
 
     dask_array_type = (da.Array,)  # for isinstance checks
 except ImportError:
-    da = None
     dask_array_type = ()
 
 

--- a/xesmf/smm.py
+++ b/xesmf/smm.py
@@ -102,6 +102,28 @@ def _parse_coords_and_values(indata, n_in, n_out):
 
 
 def check_shapes(arr_shape, w_shape, shape_in, shape_out):
+    """Compare the shapes of the input array, the weights and the regridder and raises
+    potential errors.
+
+    Parameters
+    ----------
+    arr_shape : tuple of int
+      Shape of the input array with the two spatial dimensions at the end,
+      which should fit shape_in.
+    w_shape : 2-tuple of int
+      Shape of the weights (out_dim, in_dim).
+      First element should be the product of shape_out.
+      Second element should be the product of shape_in.
+    shape_in : 2-tuple of int
+      Shape of the input of the Regridder.
+    shape_out : 2-tuple of int
+      Shape of the output of the Regridder.
+
+    Raises
+    ------
+    ValueError
+      If any of the conditions is not respected.
+    """
 
     # COO matrix is fast with F-ordered array but slow with C-array, so we
     # take in a C-ordered and then transpose)
@@ -112,16 +134,17 @@ def check_shapes(arr_shape, w_shape, shape_in, shape_out):
     # get input shape information
     shape_horiz = arr_shape[-2:]
 
-    assert shape_horiz == shape_in, (
-        'The horizontal shape of input data is {}, different from that of'
-        'the regridder {}!'.format(arr_shape[-2:], shape_in)
-    )
+    if shape_horiz != shape_in:
+        raise ValueError(
+            f'The horizontal shape of input data is {shape_horiz}, different from that '
+            f'of the regridder {shape_in}!'
+        )
 
-    assert shape_in[0] * shape_in[1] == w_shape[1], 'ny_in * nx_in should equal to weights.shape[1]'
+    if shape_in[0] * shape_in[1] != w_shape[1]:
+        raise ValueError('ny_in * nx_in should equal to weights.shape[1]')
 
-    assert (
-        shape_out[0] * shape_out[1] == w_shape[0]
-    ), 'ny_out * nx_out should equal to weights.shape[0]'
+    if shape_out[0] * shape_out[1] != w_shape[0]:
+        raise ValueError('ny_out * nx_out should equal to weights.shape[0]')
 
 
 def apply_weights(weights, indata, shape_in, shape_out):

--- a/xesmf/tests/test_frontend.py
+++ b/xesmf/tests/test_frontend.py
@@ -457,13 +457,20 @@ def test_regrid_dask(request, scheduler):
     regridder = xe.Regridder(ds_in, ds_out, 'conservative')
 
     indata = ds_in_chunked['data4D'].data
-    outdata = regridder(indata)
+    # Use ridiculous small chunk size value to be sure it _isn't_ impacting computation.
+    with dask.config.set({'array.chunk-size': '1MiB'}):
+        outdata = regridder(indata)
 
     assert dask.is_dask_collection(outdata)
 
     # lazy dask arrays have incorrect shape attribute due to last chunk
-    assert outdata.compute().shape == indata.shape[:-2] + horiz_shape_out
+    assert outdata.shape == indata.shape[:-2] + horiz_shape_out
     assert outdata.chunksize == indata.chunksize[:-2] + horiz_shape_out
+
+    # Check that the number of tasks hasn't exploded.
+    n_task_in = len(indata.__dask_graph__().keys())
+    n_task_out = len(outdata.__dask_graph__().keys())
+    assert (n_task_out / n_task_in) < 10
 
     outdata_ref = ds_out['data4D_ref'].values
     rel_err = (outdata.compute() - outdata_ref) / outdata_ref

--- a/xesmf/tests/test_frontend.py
+++ b/xesmf/tests/test_frontend.py
@@ -490,7 +490,7 @@ def test_regrid_dask(request, scheduler):
     # Check that the number of tasks hasn't exploded.
     n_task_in = len(indata.__dask_graph__().keys())
     n_task_out = len(outdata.__dask_graph__().keys())
-    assert (n_task_out / n_task_in) < 10
+    assert (n_task_out / n_task_in) < 3
 
     outdata_ref = ds_out['data4D_ref'].values
     rel_err = (outdata.compute() - outdata_ref) / outdata_ref


### PR DESCRIPTION
This fixes #127 and fixes #117 (maybe that one was already fixed?).

At the beginning, I tried to explore @dcherian's idea of using dask's `tensordot` directly instead of wrapping everything in a  `xr.apply_ufunc` with `dask='parallelized'`. Sadly, that didn't go as well as planned : the performance was not better, sometimes it was equal, sometimes worst. But, building on that, I moved things around to see if it could improve.  I'm a bit disappointed as this final solution is not _that_ much more performant than before...

The dask graph issue (127) is fixed explicitly by wrapping the weights into a dask array ourselves. I could have done just that, but the changes here have the following bonuses:
- Reorder the checks and the computation : shape checks are now done _before_ the computation, which means a wrongly shaped input using dask will raise an error on the line calling the regridder, instead of further down in the `load()` or `to_netcdf` call.
- The number of dasks added by the Regridder is now Nchunks + 1, no more. It's slightly better than before (master).
- It erases the fix of #122. Dask is now made aware of the output dtype outside of xarray, so dtype is preseved on dataset without additionnal code. 

Because of this rewrite and constraints given by `regrid_dataset`, it was easier to have a single `regrid_array` that handles the switch between dask and numpy arrays. That rendered `regrid_numpy` and `regrid_dask` kinda useless, so I took the decision to deprecated them. We can remove the warnings if you think this breaking change is not necessary.

## Performances
As said above, the overall performance of this branch is quite similar to the one of the master IF we set the dask config to avoid the bug of #127. In general, it reduces the number of task in the tree, but that improvement was diluted in my tests because dask is able to optimize said tree by merging tasks. Memory-wise, the two branches are quite equivalent, both are better than v0.6.0. 

## Going forward
Overall this is a lot of lines changed for a bug fix, but it opens possibilities for handling of spatial chunks. Without `dask='parallelized`, it could be possible to have a chunked output for very large grids?

I observed serious memory usage when `skipna=True`. I'm pretty sure this could be improved by merging some operations together?

Also, now that the weights are in a sparse DataArray, we could make them 4-D instead of 2D, maybe that could reduce the  `reshape` calls and improve performance?

All things to do in further PRs.

## TL;DR
Thisfixes a bug, but introduces many less important changes because it was coded incrementally.  If requested, I can redo another PR with only the bug-fixing change.


## EDIT:
Other changes:
- The `assert` statements in prior to the regridding have been changed into ValueErrors, for more pythonic code.
