### PR TITLE
Fix dependencies - sparse and numba

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.1.0
+    rev: v4.2.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
@@ -10,7 +10,7 @@ repos:
       - id: double-quote-string-fixer
 
   - repo: https://github.com/psf/black
-    rev: 21.12b0
+    rev: 22.3.0
     hooks:
       - id: black
 
@@ -34,7 +34,7 @@ repos:
       - id: isort
 
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v2.5.1
+    rev: v2.6.2
     hooks:
       - id: prettier
 

--- a/ci/environment-upstream-dev.yml
+++ b/ci/environment-upstream-dev.yml
@@ -6,13 +6,14 @@ dependencies:
   - codecov
   - dask
   - esmpy
+  - numba
   - numpy
   - pip
   - pre-commit
   - pydap
   - pytest
   - pytest-cov
-  - sparse
+  - sparse>=0.8.0
   - pip:
       - git+https://github.com/pydata/xarray.git
       - git+https://github.com/xarray-contrib/cf-xarray.git

--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -7,6 +7,7 @@ dependencies:
   - codecov
   - dask
   - esmpy
+  - numba
   - numpy
   - pip
   - pre-commit
@@ -14,5 +15,5 @@ dependencies:
   - pytest
   - pytest-cov
   - shapely
-  - sparse
+  - sparse>=0.8.0
   - xarray>=0.17.0

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,8 @@ else:
         'numpy>=1.16',
         'shapely',
         'cf-xarray>=0.5.1',
-        'sparse',
+        'sparse>=0.8.0',
+        'numba',
     ]
 
 CLASSIFIERS = [

--- a/xesmf/tests/test_frontend.py
+++ b/xesmf/tests/test_frontend.py
@@ -327,8 +327,8 @@ def test_regrid_with_1d_grid():
 
 
 def test_regrid_with_1d_grid_infer_bounds():
-    ds_in_1d = ds_2d_to_1d(ds_in).rename(x='lon', y='lat')
-    ds_out_1d = ds_2d_to_1d(ds_out).rename(x='lon', y='lat')
+    ds_in_1d = ds_2d_to_1d(ds_in).swap_dims(x='lon', y='lat')
+    ds_out_1d = ds_2d_to_1d(ds_out).swap_dims(x='lon', y='lat')
 
     regridder = xe.Regridder(ds_in_1d, ds_out_1d, 'conservative', periodic=True)
 

--- a/xesmf/tests/test_frontend.py
+++ b/xesmf/tests/test_frontend.py
@@ -280,9 +280,12 @@ def test_regrid_periodic_correct():
 
 def ds_2d_to_1d(ds):
     ds_temp = ds.reset_coords()
-    ds_1d = xr.merge([ds_temp['lon'][0, :], ds_temp['lat'][:, 0]])
-    ds_1d.coords['lon'] = ds_1d['lon']
-    ds_1d.coords['lat'] = ds_1d['lat']
+    ds_1d = xr.Dataset(
+        coords={
+            'lon': xr.DataArray(ds_temp['lon'][0, :], dims=('lon',)),
+            'lat': xr.DataArray(ds_temp['lat'][:, 0], dims=('lat',)),
+        }
+    )
     return ds_1d
 
 
@@ -315,20 +318,20 @@ def test_regrid_with_1d_grid():
 
     regridder = xe.Regridder(ds_in_1d, ds_out_1d, 'bilinear', periodic=True)
 
-    dr_out = regridder(ds_in['data'])
+    dr_out = regridder(ds_in['data']).rename(lon='x', lat='y')
 
     # compare with analytical solution
     rel_err = (ds_out['data_ref'] - dr_out) / ds_out['data_ref']
     assert np.max(np.abs(rel_err)) < 0.065
 
     # metadata should be 1D
-    assert_equal(dr_out['lon'].values, ds_out_1d['lon'].values)
-    assert_equal(dr_out['lat'].values, ds_out_1d['lat'].values)
+    assert_equal(dr_out['x'].values, ds_out_1d['lon'].values)
+    assert_equal(dr_out['y'].values, ds_out_1d['lat'].values)
 
 
 def test_regrid_with_1d_grid_infer_bounds():
-    ds_in_1d = ds_2d_to_1d(ds_in).rename(x='lon', y='lat')
-    ds_out_1d = ds_2d_to_1d(ds_out).rename(x='lon', y='lat')
+    ds_in_1d = ds_2d_to_1d(ds_in)
+    ds_out_1d = ds_2d_to_1d(ds_out)
 
     regridder = xe.Regridder(ds_in_1d, ds_out_1d, 'conservative', periodic=True)
 


### PR DESCRIPTION
Fixes #158 

I tried sparse 0.7.0, 0.8.0, 0.9.1 and 0.10.0 (current is 0.13.0) and only 0.7.0 made the test suite fail. I thus assumed the minimum version to be 0.8.0.

Our explicit use of `numba` is very superficial, I didn't really check what the minimum version would be. We could simplify the code by pinning 0.55, but that's the last minor version, it felt too soon to pin only to remove half a line.

I also updated the pre-commit hooks (there was a bug with my version of black).