### PR TITLE
Issues when Regridding masked data + dump to netCDF

### DIFF
--- a/xesmf/frontend.py
+++ b/xesmf/frontend.py
@@ -639,8 +639,8 @@ class BaseRegridder(object):
         """Save weights to disk as a netCDF file."""
         if filename is None:
             filename = self.filename
-        #w = self.weights.data
-        w=sps.COO.from_numpy( self.weights.data )
+        # w = self.weights.data
+        w = sps.COO.from_numpy(self.weights.data)
         dim = 'n_s'
         ds = xr.Dataset(
             {'S': (dim, w.data), 'col': (dim, w.coords[1, :] + 1), 'row': (dim, w.coords[0, :] + 1)}

--- a/xesmf/frontend.py
+++ b/xesmf/frontend.py
@@ -639,7 +639,8 @@ class BaseRegridder(object):
         """Save weights to disk as a netCDF file."""
         if filename is None:
             filename = self.filename
-        w = self.weights.data
+        #w = self.weights.data
+        w=sps.COO.from_numpy( self.weights.data )
         dim = 'n_s'
         ds = xr.Dataset(
             {'S': (dim, w.data), 'col': (dim, w.coords[1, :] + 1), 'row': (dim, w.coords[0, :] + 1)}

--- a/xesmf/smm.py
+++ b/xesmf/smm.py
@@ -218,7 +218,8 @@ def add_nans_to_weights(weights):
 
     # Taken from @trondkr and adapted by @raphaeldussin to use `lil`.
     # lil matrix is better than CSR when changing sparsity
-    m = weights.data.to_scipy_sparse().tolil()
+    # m = weights.data.to_scipy_sparse().tolil()
+    m = sps.COO.from_numpy(weights.data).to_scipy_sparse().tolil()
     # replace empty rows by one NaN value at element 0 (arbitrary)
     # so that remapped element become NaN instead of zero
     for krow in range(len(m.rows)):


### PR DESCRIPTION
# Quick description 

Issues connected to the handling of the regridding weights as a sparse.COO array and/or an xarray.DataArray backed by a sparse.COO array.

1. Issue 1 :
   ```
   AttributeError: 'numpy.ndarray' object has no attribute
   'to_scipy_sparse'
   ```
    Arises when the regriding involves source/destination grids with masked data (extrapolation).

2. Issue 2 :
   ```
   AttributeError: 'numpy.ndarray' object has no attribute 'coords'
   ```
   Arises when writing the regridding weights to a netCDF file with the dedicated Class BaseRegridder method.

# Full description 

[Demonstration with jupyter-notebook : package versions, raised error, proposed fix and tests...](ttps://github.com/lemieuxbenedicte/xESMF/blob/master/doc/notebook/Large_size_problems_Structured_grids_with_mask_FIX10_Issue9_with_xarray_DataArray_backed_by_sparse_COO.ipynb?)
