### PR TITLE
Constrain numba >= 0.55.2 to make sure xESMF works with numpy 1.22.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,10 @@ Documentation
 - Fix typos (:pull:`191`). By `Jemma Stachelek <https://github.com/jsta>`_
 - Copy-editing (:pull:`178`, :pull:`179`). By `RichardScottOZ <https://github.com/RichardScottOZ>`_
 
+Internal changes
+~~~~~~~~~~~~~~~~
+- Constrain `numba>=0.55.2`. See (:issue:`185`).
+
 
 0.6.3 (29-06-2022)
 ------------------

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ else:
         'shapely',
         'cf-xarray>=0.5.1',
         'sparse>=0.8.0',
-        'numba',
+        'numba >=0.55.2',
     ]
 
 CLASSIFIERS = [


### PR DESCRIPTION
Closes #185