### PR TITLE
Modify the `stop` argument in arange to avoid coordinates going over the right bound

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,10 @@ What's new
 0.6.4 (unreleased)
 ------------------
 
+Bug fixes
+~~~~~~~~~
+- Fix bug in `util.grid_global` where grid centers could go beyond 180 degrees (:issue:`181`). By `David Huard <https://github.com/huard>`_
+
 Documentation
 ~~~~~~~~~~~~~
 - Fix API doc build (:pull:`194`). By `David Huard <https://github.com/huard>`_

--- a/xesmf/tests/test_util.py
+++ b/xesmf/tests/test_util.py
@@ -4,6 +4,7 @@ import xesmf as xe
 
 
 def test_grid_global():
+
     ds = xe.util.grid_global(1.5, 1.5)
     refshape = (120, 240)
     refshape_b = (121, 241)
@@ -12,6 +13,12 @@ def test_grid_global():
     assert ds['lat'].values.shape == refshape
     assert ds['lon_b'].values.shape == refshape_b
     assert ds['lat_b'].values.shape == refshape_b
+
+    # Issue #181 (https://github.com/pangeo-data/xESMF/issues/181)
+    d_lon = 360 / 4320
+    d_lat = 180 / 2160
+    ds = xe.util.grid_global(d_lon, d_lat)
+    assert ds.lon.max() <= 180
 
 
 def test_grid_global_bad_resolution():

--- a/xesmf/util.py
+++ b/xesmf/util.py
@@ -27,7 +27,7 @@ def _grid_1d(start_b, end_b, step):
     bounds : 1D numpy array, with one more element than centers
     """
 
-    bounds = np.arange(start_b, end_b + step, step)
+    bounds = np.arange(start_b, end_b + step / 2, step)
     centers = (bounds[:-1] + bounds[1:]) / 2
 
     return centers, bounds
@@ -148,13 +148,13 @@ def grid_global(d_lon, d_lat, cf=False):
     if not np.isclose(360 / d_lon, 360 // d_lon):
         warnings.warn(
             '360 cannot be divided by d_lon = {}, '
-            'might not cover the globe uniformally'.format(d_lon)
+            'might not cover the globe uniformly'.format(d_lon)
         )
 
     if not np.isclose(180 / d_lat, 180 // d_lat):
         warnings.warn(
             '180 cannot be divided by d_lat = {}, '
-            'might not cover the globe uniformally'.format(d_lat)
+            'might not cover the globe uniformly'.format(d_lat)
         )
 
     if cf:


### PR DESCRIPTION
Fixes #181