### PR TITLE
Unpin and fix for Shapely 2.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,13 @@
 What's new
 ==========
 
+0.7.1 (unreleased)
+------------------
+
+Bug fixes
+~~~~~~~~~
+- Fix ``Mesh.from_polygons`` to support ``shapely`` 2.0. By `Pascal Bourgault <https://github.com/aulemahal>`_.
+
 0.7.0 (2022-12-16)
 ------------------
 

--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -1,4 +1,4 @@
-name: xesmf
+name: xesmf-shp2
 channels:
   - conda-forge
 dependencies:
@@ -14,6 +14,6 @@ dependencies:
   - pydap
   - pytest
   - pytest-cov
-  - shapely<2.0
+  - shapely
   - sparse>=0.8.0
   - xarray>=0.17.0

--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -1,4 +1,4 @@
-name: xesmf-shp2
+name: xesmf
 channels:
   - conda-forge
 dependencies:

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ else:
         'esmpy>=8.0.0',
         'xarray>=0.16.2',
         'numpy>=1.16',
-        'shapely<2.0',
+        'shapely',
         'cf-xarray>=0.5.1',
         'sparse>=0.8.0',
         'numba >=0.55.2',

--- a/xesmf/backend.py
+++ b/xesmf/backend.py
@@ -251,7 +251,7 @@ class Mesh(ESMF.Mesh):
         mesh : ESMF.Mesh
             A mesh where each polygon is represented as an Element.
         """
-        node_num = sum(e.exterior.coords.array_interface()['shape'][0] - 1 for e in polys)
+        node_num = sum(len(e.exterior.coords) - 1 for e in polys)
         elem_num = len(polys)
         # Pre alloc arrays. Special structure for coords makes the code faster.
         crd_dt = np.dtype([('x', np.float32), ('y', np.float32)])


### PR DESCRIPTION
This PR modifies this single line of code that was making xESMF fail with shapely 2.0. The fix works with shapely 1.8. I'm not sure why I wrote it the way it was written, but everything passes now, so...