### PR TITLE
Fix ci/cd badge for build status

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -26,7 +26,7 @@ For new users, I also recommend reading `How to ask for help <https://xesmf.read
 .. |conda| image:: https://anaconda.org/conda-forge/xesmf/badges/version.svg
    :target: https://anaconda.org/conda-forge/xesmf/
 
-.. |Build Status| image:: https://img.shields.io/github/workflow/status/pangeo-data/xESMF/CI?logo=github
+.. |Build Status| image:: https://img.shields.io/github/actions/workflow/status/pangeo-data/xESMF/ci.yaml?branch=master
    :target: https://github.com/pangeo-data/xESMF/actions
    :alt: github-ci build status
 


### PR DESCRIPTION
There is a change mentionned at https://github.com/badges/shields/issues/8671 which needs to be applied for the shields badges to work again