### PR TITLE
do not publish wheel

### DIFF
--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -32,7 +32,7 @@ jobs:
           python -m pip install --upgrade build
 
       - name: Build binary wheel
-        run: python -m build --sdist --wheel . --outdir dist
+        run: python -m build --sdist . --outdir dist
 
       - name: CheckFiles
         run: |


### PR DESCRIPTION
We can only do this after we close https://github.com/conda-forge/esmpy-feedstock/issues/72