### PR TITLE
Removed 3.7 from supported versions. Build docs using 3.9

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,7 +28,7 @@ jobs:
             esmf-version: 8.3
           - python-version: '3.10'
             esmf-version: 8.4
-          # - python-version: 3.11  # Numba is incompatible with 3.11
+          # - python-version: '3.11'
           #  esmf-version: 8.4
     steps:
       - name: Cancel previous runs

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,16 @@
 What's new
 ==========
 
+0.7.2 (unreleased)
+------------------
+
+Internal changes
+~~~~~~~~~~~~~~~~
+* Pin sphinx < 7.0 since it's not supported by `sphinx_rtd_theme`
+* Remove Python 3.7 from the project classifiers
+* Build docs using Python 3.9
+
+
 0.7.1 (2023-04-03)
 ------------------
 

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -11,7 +11,8 @@ The `Binder project <https://mybinder.readthedocs.io>`_ provides pre-configured 
 Install on local machine with Conda
 -----------------------------------
 
-xESMF requires Python>=3.7. The major dependencies are xarray and ESMPy. The best way to install them is using Conda_.
+xESMF requires Python>=3.8. The major dependencies are xarray and ESMPy, and the best way to install them is using Conda_.
+Note that the latest xarray releases require Python 3.9 or later.
 
 First, `install miniconda <https://docs.conda.io/projects/conda/en/latest/user-guide/install/index.html>`_. Then, we recommend creating a new, clean environment:
 

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -4,7 +4,7 @@ descartes
 ipython
 Pygments>=2.6
 nbsphinx
-sphinx
+sphinx<7
 sphinx_rtd_theme
 cf_xarray
 docutils!=0.18

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,6 @@ classifiers = [
     'Intended Audience :: Science/Research',
     'Programming Language :: Python',
     'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.7',
     'Programming Language :: Python :: 3.8',
     'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -3,7 +3,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: '3.8'
+    python: '3.9'
 
 python:
   install:


### PR DESCRIPTION
RtD problem was caused by a new Sphinx version (7.0), which is not yet supported by sphinx_rtd_theme.