### PR TITLE
Perform ci tests with python 3.11 now that numba is compatible.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,8 +28,8 @@ jobs:
             esmf-version: 8.3
           - python-version: '3.10'
             esmf-version: 8.4
-          # - python-version: 3.11  # Numba is incompatible with 3.11
-          #  esmf-version: 8.4
+          - python-version: 3.11
+            esmf-version: 8.4
     steps:
       - name: Cancel previous runs
         uses: styfle/cancel-workflow-action@0.11.0


### PR DESCRIPTION
Changed .github/workflows/ci.yaml to include python 3.11 since numba 0.57.0 is now compatible with python 3.11