### PR TITLE
Correctly guess output chunks for SpatialAverager

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,13 +1,19 @@
 What's new
 ==========
 
+0.8.2 (unreleased)
+------------------
+
+Bug fixes
+~~~~~~~~~
+* Correct guess of output chunks for the :``SpatialAverager``.
+
 0.8.1 (2023-09-05)
 ------------------
 
 Bug fixes
 ~~~~~~~~~
 * Change import to support shapely 1 and 2.
-
 
 0.8.0 (2023-09-01)
 ------------------

--- a/xesmf/frontend.py
+++ b/xesmf/frontend.py
@@ -593,7 +593,9 @@ class BaseRegridder(object):
         weights = self.weights.data.reshape(self.shape_out + self.shape_in)
         if isinstance(indata, dask_array_type):  # dask
             if output_chunks is None:
-                output_chunks = tuple([min(shp, inchnk) for shp, inchnk in zip(self.shape_out, indata.chunksize[-2:])])
+                output_chunks = tuple(
+                    [min(shp, inchnk) for shp, inchnk in zip(self.shape_out, indata.chunksize[-2:])]
+                )
             if len(output_chunks) != len(self.shape_out):
                 if len(output_chunks) == 1 and self.sequence_out:
                     output_chunks = (1, output_chunks[0])

--- a/xesmf/frontend.py
+++ b/xesmf/frontend.py
@@ -590,21 +590,22 @@ class BaseRegridder(object):
 
         kwargs.update(skipna=skipna, na_thres=na_thres)
 
+        weights = self.weights.data.reshape(self.shape_out + self.shape_in)
         if isinstance(indata, dask_array_type):  # dask
             if output_chunks is None:
-                output_chunks = indata.chunksize[-2:]
-            elif output_chunks is not None:
-                if len(output_chunks) != len(self.shape_out):
+                output_chunks = tuple([min(shp, inchnk) for shp, inchnk in zip(self.shape_out, indata.chunksize[-2:])])
+            if len(output_chunks) != len(self.shape_out):
+                if len(output_chunks) == 1 and self.sequence_out:
+                    output_chunks = (1, output_chunks[0])
+                else:
                     raise ValueError(
                         f'output_chunks must have same dimension as ds_out,'
                         f' output_chunks dimension ({len(output_chunks)}) does not '
                         f'match ds_out dimension ({len(self.shape_out)})'
                     )
-            weights = da.from_array(self.w.data, chunks=(output_chunks + indata.chunksize[-2:]))
-
+            weights = da.from_array(weights, chunks=(output_chunks + indata.chunksize[-2:]))
             outdata = self._regrid(indata, weights, **kwargs)
         else:  # numpy
-            weights = self.w.data  # 4D weights
             outdata = self._regrid(indata, weights, **kwargs)
         return outdata
 

--- a/xesmf/tests/test_frontend.py
+++ b/xesmf/tests/test_frontend.py
@@ -7,8 +7,8 @@ import numpy as np
 import pytest
 import xarray as xr
 from numpy.testing import assert_allclose, assert_almost_equal, assert_equal
-from shapely.geometry import MultiPolygon, Polygon
 from shapely import segmentize
+from shapely.geometry import MultiPolygon, Polygon
 
 import xesmf as xe
 from xesmf.frontend import as_2d_mesh

--- a/xesmf/tests/test_frontend.py
+++ b/xesmf/tests/test_frontend.py
@@ -8,6 +8,7 @@ import pytest
 import xarray as xr
 from numpy.testing import assert_allclose, assert_almost_equal, assert_equal
 from shapely.geometry import MultiPolygon, Polygon
+from shapely import segmentize
 
 import xesmf as xe
 from xesmf.frontend import as_2d_mesh
@@ -780,18 +781,22 @@ def test_ds_to_ESMFlocstream():
         locstream, shape, names = ds_to_ESMFlocstream(ds_bogus)
 
 
+@pytest.mark.parametrize('use_dask', [True, False])
 @pytest.mark.parametrize('poly,exp', list(zip(polys, exps_polys)))
-def test_spatial_averager(poly, exp):
+def test_spatial_averager(poly, exp, use_dask):
     if isinstance(poly, (Polygon, MultiPolygon)):
         poly = [poly]
-    savg = xe.SpatialAverager(ds_savg, poly, geom_dim_name='my_geom')
-    out = savg(ds_savg.abc)
+    if use_dask:
+        ds_in = ds_savg.chunk(lat=10)
+    else:
+        ds_in = ds_savg
+    savg = xe.SpatialAverager(ds_in, poly, geom_dim_name='my_geom')
+    out = savg(ds_in.abc)
     assert_allclose(out, exp, rtol=1e-3)
 
     assert 'my_geom' in out.dims
 
 
-@pytest.mark.xfail
 def test_spatial_averager_with_zonal_region():
     # We expect the spatial average for all regions to be one
     zonal_south = Polygon([(0, -90), (10, 0), (0, 0)])
@@ -800,6 +805,7 @@ def test_spatial_averager_with_zonal_region():
     zonal_full = Polygon([(0, -90), (10, 0), (0, 90), (0, 0)])  # This yields 0... why?
 
     polys = [zonal_south, zonal_north, zonal_short, zonal_full]
+    polys = segmentize(polys, 1)
 
     # Create field of ones on a global grid
     ds = xe.util.grid_global(20, 12, cf=True)


### PR DESCRIPTION
The `SpatialAverager.w`  property outputs an intuitive 3D weights array. However, the mechanism to guess output chunks (when None is passed, the default) is in the `BaseRegridder` and it assumed that  `w` was 4D.

This PR changes how we guess those output chunks:

- Default chunks at most as large as the out shape.
- Don't use `self.w` internally. I take the stance that `self.w` is for the user, meaning we can make it as intuitive as possible. The regridder mechanism makes the non-intuiive choice of using an out shape of (1, N) for the SpatialAverager, so I use the `self.weights` array directly instead. Also, we didn't need the DataArray container, so it removed (minimal) overhead.
- Accept len-1 `output_chunks` when it's a `sequence_out`, but add the dummy singleton dimension before passing to dask.
- Add `SpatialAverager` tests with dask. We missed the error because we were lacking this test.

This PR also reactivates the large region tests, adding a `segmentize` call, so it passes. Not sure how useful that test is, but it also doesn't cost much to keep it.
