### PR TITLE
Remove function from private xarray module

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,7 @@ Bug fixes
 ~~~~~~~~~
 * Raise a meaningful error messages when the output grid has no chunks with `parallel=True` (:issue:`299`, :pull:`304`). By `Pascal Bourgault <https://github.com/aulemahal>`_.
 * Correct guess of output chunks for the :``SpatialAverager``.
+* Remove usage of private method of xarray that was removed in its 2024.02.0 version.
 
 0.8.1 (2023-09-05)
 ------------------

--- a/xesmf/frontend.py
+++ b/xesmf/frontend.py
@@ -998,8 +998,7 @@ class Regridder(BaseRegridder):
             ds_in = ds_in.coords.to_dataset()
 
         # Ensure ds_in is not dask-backed
-        if xr.core.pycompat.is_dask_collection(ds_in):
-            ds_in = ds_in.compute()
+        ds_in = ds_in.load()
 
         # if bounds in ds_out, we switch to cf bounds for map_blocks
         if 'lon_b' in ds_out and (ds_out.lon_b.ndim == ds_out.cf['longitude'].ndim):


### PR DESCRIPTION
Fixes #338 

We were using a method from `xr.core.pycompat` that was removed. That module is private, so this was a mistake on our end.

Also, the method was only used to check if a dataArray was dask-backed and load it if it was. However, calling `load()` on any array has the exact same effect anyway.

Seeing how this impacted downstream packages, this might warrant a minor or patch release!