### PR TITLE
Prepare v0.8.3

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,14 +1,22 @@
 What's new
 ==========
 
-0.8.2 (2024-02-20)
+0.8.3 (2024-02-20)
+------------------
+* Remove usage of private method of xarray that was removed in its 2024.02.0 version (:issue:`338`, :issue:`340`) By `Pascal Bourgault <https://github.com/aulemahal>`_.
+
+Internal changes
+----------------
+* Test against ESMF 8.6
+
+
+0.8.2 (2023-09-18)
 ------------------
 
 Bug fixes
 ~~~~~~~~~
 * Raise a meaningful error messages when the output grid has no chunks with `parallel=True` (:issue:`299`, :pull:`304`). By `Pascal Bourgault <https://github.com/aulemahal>`_.
 * Correct guess of output chunks for ``SpatialAverager``.
-* Remove usage of private method of xarray that was removed in its 2024.02.0 version.
 
 Internal changes
 ----------------


### PR DESCRIPTION
Woopsi.

`CHANGES.rst` hadn't been updated for version 0.8.2, so I was mistaken with the next release's version number.

We actually need to release 0.8.3 which only contains the bug fix for xarray 2024.02.0.