### PR TITLE
Fix parallel regridder regression and version 0.8.4

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,10 +21,6 @@ Bug fixes
 * Raise a meaningful error messages when the output grid has no chunks with `parallel=True` (:issue:`299`, :pull:`304`). By `Pascal Bourgault <https://github.com/aulemahal>`_.
 * Correct guess of output chunks for ``SpatialAverager``.
 
-Internal changes
-----------------
-* Test against ESMF 8.6
-
 0.8.1 (2023-09-05)
 ------------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,10 @@
 What's new
 ==========
 
+0.8.4 (2024-02-26)
+------------------
+* Fix regression from :pull:`332` that made ``Regridder`` fail with rectilinear datasets and ``parallel=True``. (:issue:`343`, :pull:`344`).
+
 0.8.3 (2024-02-20)
 ------------------
 * Remove usage of private method of xarray that was removed in its 2024.02.0 version (:issue:`338`, :issue:`340`) By `Pascal Bourgault <https://github.com/aulemahal>`_.
@@ -8,7 +12,6 @@ What's new
 Internal changes
 ----------------
 * Test against ESMF 8.6
-
 
 0.8.2 (2023-09-18)
 ------------------

--- a/xesmf/frontend.py
+++ b/xesmf/frontend.py
@@ -1031,7 +1031,9 @@ class Regridder(BaseRegridder):
 
         # Rename coords to avoid issues in xr.map_blocks
         for coord in list(self.out_coords.keys()):
-            ds_out = ds_out.rename({coord: coord + '_out'})
+            # If coords and dims are the same, renaming has already been done.
+            if coord not in self.out_horiz_dims:
+                ds_out = ds_out.rename({coord: coord + '_out'})
 
         weights_dims = ('y_out', 'x_out', 'y_in', 'x_in')
         templ = sps.zeros((self.shape_out + self.shape_in))

--- a/xesmf/tests/test_frontend.py
+++ b/xesmf/tests/test_frontend.py
@@ -634,6 +634,21 @@ def test_para_weight_gen():
     # weights should be identical between serial and parallel
     assert all(regridder.w.data.data == para_regridder.w.data.data)
 
+    # Should work with a rectilinear version too (where dims == coords)
+    ds_in_cf = xe.util.cf_grid_2d(-90, 90, 20, -45, 45, 12)
+    ds_out_cf = xe.util.cf_grid_2d(-90, 90, 15, -45, 45, 9)
+    ds_in_cf['data'] = xe.data.wave_smooth(ds_in_cf['lon'], ds_in_cf['lat'])
+    ds_out_cf['data_ref'] = xe.data.wave_smooth(ds_out_cf['lon'], ds_out_cf['lat']).chunk(
+        {'lat': 5, 'lon': 5}
+    )
+
+    # Generating weights in serial and parallel
+    regridder = xe.Regridder(ds_in_cf, ds_out_cf, 'conservative')
+    para_regridder = xe.Regridder(ds_in_cf, ds_out_cf, 'conservative', parallel=True)
+
+    # weights should be identical between serial and parallel
+    assert all(regridder.w.data.data == para_regridder.w.data.data)
+
     # Ensure para weight gen works with locstream_in as well
     reggrider_locs = xe.Regridder(ds_locs, ds_out_chunked, 'nearest_s2d', locstream_in=True)
     para_regridder_locs = xe.Regridder(


### PR DESCRIPTION
Another patch release for a quick fix.

Fixes #343 by skipping the rename if the coordinate has the same name as a dimension, in which cas renaming has already been done. I also added a test of the parallel regridder for that case.

We didn't catch that because our test dataset is "curvilinear", i.e. the dimensions are different from the coords (which are 2D). The bug was affecting rectilinear datasets (coords == dims, both 1D).

Finally, I removed a duplicated in the CHANGES.