### PR TITLE
Warn when number of chunks increases too much

### DIFF
--- a/xesmf/frontend.py
+++ b/xesmf/frontend.py
@@ -596,6 +596,19 @@ class BaseRegridder(object):
                 output_chunks = tuple(
                     [min(shp, inchnk) for shp, inchnk in zip(self.shape_out, indata.chunksize[-2:])]
                 )
+                fac = np.prod(
+                    [np.ceil(shp / inchnk) for shp, inchnk in zip(self.shape_out, indata.chunksize[-2:])]
+                )
+                if fac > 4:  # Dask's built-in threshold is 10
+                    warnings.warn(
+                        (
+                            f"Regridding is increasing the number of chunks by a factor of {fac}, "
+                            "you might want to specify sizes in `output_chunks` in the regridder call. "
+                            f"Default behaviour is to preserve the chunk sizes from the input {indata.chunksize[-2:]}."
+                        ),
+                        da.core.PerformanceWarning,
+                        stacklevel=3
+                    )
             if len(output_chunks) != len(self.shape_out):
                 if len(output_chunks) == 1 and self.sequence_out:
                     output_chunks = (1, output_chunks[0])


### PR DESCRIPTION
#280 introduced support for chunking along the spatial dimensions. It also introduced a new behaviour : the regridded output has chunks of the same size as the input, unless otherwise specified.  For regridding that increases the resolution and for a dataset that has no chunks along the spatial dims, this is a different behaviour than the previous code, and it might be unexpected. 

For example, going from a 64x64 grid with a single 64x64 chunk to a 128x128 grid, increases the number of chunks to 4. The regridding always adds 3 blockwise tasks in the dask graph, and thus the graph can grow faster than expected.

I think our default makes sense, but I think adding a warning might help the users understand what's happening.

I am waiting on a colleague to see if explicitly setting `output_chunks` is enough to retrieve the expected performance in some edge cases.