### PR TITLE
Another numpy 2 fix

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,10 @@
 What's new
 ==========
 
+0.8.7 (unreleased)
+------------------
+* Cast grid sizes to python's int (another Numpy 2.0 fix). (:pull:`377`) By `Pascal Bourgault <https://github.com/aulemahal>`_.
+
 0.8.6 (2024-06-26)
 ------------------
 * New ``xe.util.cell_area`` utility to compute the cell area using ESMF's internal mechanism. (:pull:`372`, :issue:`369`) By `Jiawei Zhuang <https://github.com/JiaweiZhuang>`_  and `Pascal Bourgault <https://github.com/aulemahal>`_.

--- a/xesmf/backend.py
+++ b/xesmf/backend.py
@@ -146,7 +146,8 @@ class Grid(ESMF.Grid):
 
     def get_shape(self, loc=ESMF.StaggerLoc.CENTER):
         """Return shape of grid for specified StaggerLoc"""
-        return tuple(self.size[loc])
+        # We cast explicitly to python's int (numpy >=2)
+        return tuple(map(int, self.size[loc]))
 
 
 class LocStream(ESMF.LocStream):


### PR DESCRIPTION
Fixes #315

ESMpy has stored its grid sizes in `int32` forever, but before numpy 2 our  `get_shape` function was returning normal ints while it now returns `np.int32` scalars with numpy 2.0.

The reason is that `tuple(np.array([1, 1], dtype=np.int32))` changed behaviour in numpy 2, preserving the dtype of the individual elements in the tuple, while it previously implicitly casted them with python's scalar. See https://numpy.org/doc/stable/numpy_2_0_migration_guide.html#changes-to-numpy-data-type-promotion