### PR TITLE
use cf to calculate 2d lat lon bounds

### DIFF
--- a/xesmf/frontend.py
+++ b/xesmf/frontend.py
@@ -95,9 +95,6 @@ def _get_lon_lat_bounds(ds):
         lon_bnds = ds.cf.get_bounds('longitude')
         lat_bnds = ds.cf.get_bounds('latitude')
     except KeyError:  # bounds are not already present
-        if ds.cf['longitude'].ndim > 1:
-            # We cannot infer 2D bounds, raise KeyError as custom "lon_b" is missing.
-            raise KeyError('lon_b')
         lon_name = ds.cf['longitude'].name
         lat_name = ds.cf['latitude'].name
         ds = ds.cf.add_bounds([lon_name, lat_name])
@@ -795,7 +792,7 @@ class Regridder(BaseRegridder):
             where masked values are identified by 0, and non-masked values by 1.
 
             For conservative methods, if bounds are not present, they will be
-            computed using `cf-xarray` (only 1D coordinates are currently supported).
+            computed using `cf-xarray`.
 
             Shape can be 1D (n_lon,) and (n_lat,) for rectilinear grids,
             or 2D (n_y, n_x) for general curvilinear grids.


### PR DESCRIPTION
I just ran into this issue while trying to regrid a curvilinear grid to rectilinear with the `conservative` method. This is my first pull request into a public project, so apologies if I'm doing something incorrectly.

Previously, when `lat` or `lon` was a 2D array, `xesmf` would throw key error when attempting to calculate bounds if they were not present. At the time, `cf-xarray` had no method of calculating new bounds from 2D coordinates, see #180.

However, this is no longer the case via https://github.com/xarray-contrib/cf-xarray/issues/71.

I have simply removed the conditional key error and updated the docs.