### PR TITLE
Add explicit grid destroy when deleting Regridder

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,10 @@
 What's new
 ==========
 
+0.8.8 (unreleased)
+------------------
+* Fix ESMpy memory issues by explictly freeing the Grid memory upon garbage collection of ``Regridder`` objects. By `Pascal Bourgault <https://github.com/aulemahal>`_.
+
 0.8.7 (2024-07-16)
 ------------------
 * Cast grid sizes to python's int (another Numpy 2.0 fix). (:pull:`377`) By `Pascal Bourgault <https://github.com/aulemahal>`_.

--- a/xesmf/frontend.py
+++ b/xesmf/frontend.py
@@ -1107,6 +1107,12 @@ class Regridder(BaseRegridder):
 
         return out
 
+    def __del__(self):
+        # Memory leak issue when regridding over a large number of datasets with xESMF
+        # https://github.com/JiaweiZhuang/xESMF/issues/53
+        self.grid_in.destroy()
+        self.grid_out.destroy()
+
 
 class SpatialAverager(BaseRegridder):
     def __init__(
@@ -1370,3 +1376,9 @@ class SpatialAverager(BaseRegridder):
         out.coords[self._lat_out_name] = xr.DataArray(self._lat_out, dims=(self.geom_dim_name,))
         out.attrs['regrid_method'] = self.method
         return out
+
+    def __del__(self):
+        # Memory leak issue when regridding over a large number of datasets with xESMF
+        # https://github.com/JiaweiZhuang/xESMF/issues/53
+        self.grid_in.destroy()
+        self.grid_out.destroy()


### PR DESCRIPTION
Fixes JiaweiZhuang/xESMF#53.

When the `Regridder` or `SpatialAverager` object is garage-collected, the ESMpy grid objects are not destroyed as they seem to still be referenced somewhere in the ESMpy Manager (or something alike). This change explicitly destroys the grids when the `Regridder` object is removed.

This will break any code that makes use of the Grid objects in a scope where the Regridder itself is not referenced. For example:
```python
import xesmf as xe

def get_grid(ds1, ds2):
    reg = xe.Regridder(ds, ds2)
    return reg.grid_in    
```
Will most likely return a destroyed grid object.

The other solution I see is to make a `destroy` method on the `Regridder` object that destroys underlying grids, but that demands an explicit action from the user. It won't really fix the "memory leak" feeling that users get.