### PR TITLE
Fix deprecation error in xarray 2024.10

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,7 +31,7 @@ jobs:
           - python-version: "3.11"
             esmf-version: 8.6
           - python-version: "3.12"
-            esmf-version: 8.6
+            esmf-version: 8.7
     steps:
       - name: Cancel previous runs
         uses: styfle/cancel-workflow-action@0.12.1

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ What's new
 0.8.8 (unreleased)
 ------------------
 * Fix ESMpy memory issues by explictly freeing the Grid memory upon garbage collection of ``Regridder`` objects. By `Pascal Bourgault <https://github.com/aulemahal>`_.
+* Address deprecation for xarray 2024.10 in the parallel weight generation. By `Pascal Bourgault <https://github.com/aulemahal>`_.
 
 0.8.7 (2024-07-16)
 ------------------

--- a/xesmf/frontend.py
+++ b/xesmf/frontend.py
@@ -1049,9 +1049,9 @@ class Regridder(BaseRegridder):
                 {self.out_horiz_dims[0]: 'y_out', self.out_horiz_dims[1]: 'x_out'}
             )
 
-        out_chunks = [ds_out.chunks.get(k) for k in ['y_out', 'x_out']]
-        in_chunks = [ds_in.chunks.get(k) for k in ['y_in', 'x_in']]
-        chunks = out_chunks + in_chunks
+        out_chunks = {k: ds_out.chunks.get(k) for k in ['y_out', 'x_out']}
+        in_chunks = {k: ds_in.chunks.get(k) for k in ['y_in', 'x_in']}
+        chunks = out_chunks | in_chunks
 
         # Rename coords to avoid issues in xr.map_blocks
         for coord in list(self.out_coords.keys()):


### PR DESCRIPTION
We overlooked a deprecation warning that was there for the last year, and now the recent xarray breaks the parallel weight generation...

This fixes the issue.

It also enables a CI run with ESMF 8.7 which was released 3 weeks ago.