### PR TITLE
Fix upcoming sparse change

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ What's new
 ------------------
 * Fix ESMpy memory issues by explictly freeing the Grid memory upon garbage collection of ``Regridder`` objects. By `Pascal Bourgault <https://github.com/aulemahal>`_.
 * Address deprecation for xarray 2024.10 in the parallel weight generation. By `Pascal Bourgault <https://github.com/aulemahal>`_.
+* Address an upcoming change in sparse 0.16 where COO fill values will distinguish between 0.0 and -0.0. This issue would affect spatial averaging over polygons with holes. By `Pascal Bourgault <https://github.com/aulemahal>`_.
 
 0.8.7 (2024-07-16)
 ------------------


### PR DESCRIPTION
While doing the other PR I stumbled upon an issue with sparse 0.16, which is not yet released. In the  `SpatialAverager`, when the polygon has holes, we compute the weights of the holes and then invert them. The inversion of a  `COO` array also inverts its `fill_value`. Weights are float, so a fill value of `0.0` gets reverted to `-0.0`. It seems that up to sparse 0.15.4, this was not a problem but with 0.16, the subsequent concatenation of the weights fails. I was told that this was not a bug : https://github.com/pydata/sparse/issues/802

So here is a fix for that.

Also, I modified the `__del__` methods. When the `__init__` of either `Regridder` or `SpatialAverager` fails before reaching the `super().__init__`, `self.grid_in` doesn't exist yet. The `AttributeError` raised when deleting the object is not raised in the main thread, but emits a warning instead. This avoids that.