### PR TITLE
Add sphinx config to readthedocs.yaml

### DIFF
--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -10,3 +10,9 @@ python:
     - requirements: doc/requirements.txt
     - method: pip
       path: .
+
+sphinx:
+  configuration: doc/conf.py
+  # fail_on_warning might generate hard to fix error, in this case it can be
+  # disabled but this also means those errors will fail silently, choose wisely.
+  fail_on_warning: false


### PR DESCRIPTION
Hopefully this fixes the RtD build. 

Note that I set `fail_on_warning` to false. Ideally we'd set it to true, but I don't have time right now to fix deeper issues.