### PR TITLE
Do not add scalar coords from the target grid to the regridding output

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,6 +26,7 @@ repos:
     rev: 7.1.1
     hooks:
       - id: flake8
+
   - repo: https://github.com/PyCQA/isort
     rev: 6.0.0
     hooks:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ What's new
 0.8.9 (unreleased)
 ------------------
 * Destroy grids explicitly once weights are computed. Do not store them in `grid_in` and  `grid_out` attributes. This fixes segmentation faults introduced by the memory fix of last version. By `Pascal Bourgault <https://github.com/aulemahal>`_.
+* Do not add scalar coordinates of the target grid to the regridded output (:issue:`417`, :pull:`418`). `xe.Regridder.out_coords` is now a dataset instead of a dictionary. By `Pascal Bourgault <https://github.com/aulemahal>`_.
 
 0.8.8 (2024-11-01)
 ------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ tag_regex = "^(?P<prefix>v)?(?P<version>[^\\+]+)(?P<suffix>.*)?$"
 [tool.black]
 line-length = 100
 target-version = [
-  'py310',
+  'py311',
 ]
 skip-string-normalization = true
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,4 +7,4 @@ ignore =
 max-line-length = 100
 max-complexity = 18
 select = B,C,E,F,W,T4,B9
-extend-ignore = E203,E501,E402,W605
+extend-ignore = E203,E501,E402,W503,W605

--- a/xesmf/tests/test_frontend.py
+++ b/xesmf/tests/test_frontend.py
@@ -732,17 +732,22 @@ def test_regrid_dataset_extracoords():
         x=np.arange(24),
         y=np.arange(20),  # coords to be transfered
         latitude_longitude=xr.DataArray(),  # grid_mapping
-        bogus=ds_out.lev * ds_out.lon,  # coord not to be transfered
+        bogus=ds_out.lev * ds_out.lon,  # coords not to be transfered
+        scalar1=1,  #
+        scalar2=1,  #
     )
     ds_out2['data_ref'].attrs['grid_mapping'] = 'latitude_longitude'
     ds_out2['data4D_ref'].attrs['grid_mapping'] = 'latitude_longitude'
 
+    ds_in2 = ds_in.assign_coords(scalar2=5)
     regridder = xe.Regridder(ds_in, ds_out2, 'conservative')
-    ds_result = regridder(ds_in)
+    ds_result = regridder(ds_in2)
 
     assert 'x' in ds_result.coords
     assert 'y' in ds_result.coords
     assert 'bogus' not in ds_result.coords
+    assert 'scalar1' not in ds_result.coords
+    assert ds_result.scalar2 == 5
     assert 'latitude_longitude' in ds_result.coords
 
 


### PR DESCRIPTION
As title says.

Fixes #417.

As a way to make this easier, I changed the type of `Regridder.out_coords` from a dictionary to a dataset.