### PR TITLE
Fix passing grid as dictionary

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,10 @@
 What's new
 ==========
 
+0.8.10 (unreleased)
+-------------------
+* Fix issue introduced by :pull:`418` for passing grids as dictionaries. (:issue:`428`, :pull:`429`). By `Pascal Bourgault <https://github.com/aulemahal>`_.
+
 0.8.9 (2025-04-15)
 ------------------
 * Destroy grids explicitly once weights are computed. Do not store them in `grid_in` and  `grid_out` attributes. This fixes segmentation faults introduced by the memory fix of last version. By `Pascal Bourgault <https://github.com/aulemahal>`_.

--- a/xesmf/frontend.py
+++ b/xesmf/frontend.py
@@ -980,7 +980,7 @@ class Regridder(BaseRegridder):
                 ]
             )
         else:
-            self.out_coords = {lat_out.name: lat_out, lon_out.name: lon_out}
+            self.out_coords = xr.Dataset(coords={lat_out.name: lat_out, lon_out.name: lon_out})
 
         if parallel:
             self._init_para_regrid(ds_in, ds_out, kwargs)

--- a/xesmf/tests/conftest.py
+++ b/xesmf/tests/conftest.py
@@ -14,7 +14,7 @@ def processes_scheduler():
         yield
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope='function')
 def distributed_scheduler():
     from dask.distributed import Client, LocalCluster
 

--- a/xesmf/tests/test_oceanmodels.py
+++ b/xesmf/tests/test_oceanmodels.py
@@ -75,7 +75,8 @@ def test_mom6like_to_5x5():
         mom6like.rename({'xh': 'lon', 'yh': 'lat'}), grid_5x5, 'bilinear', periodic=True
     )
 
-    tos_regridded = regrid_to_5x5(mom6like['tos'])
+    with pytest.warns(UserWarning, match=r"Using dimensions \('yh', 'xh'\)"):
+        tos_regridded = regrid_to_5x5(mom6like['tos'])
     assert tos_regridded.shape == ((2, 36, 72))
 
 


### PR DESCRIPTION
Fixes #428.

Also detects or filters almost all warnings, so that we can use pytest's warning detection in a meaningful way.