### PR TITLE
Enabling target mask for LocStream input

### DIFF
--- a/xesmf/frontend.py
+++ b/xesmf/frontend.py
@@ -380,11 +380,16 @@ class BaseRegridder(object):
             # Optionally post-apply output mask for LocStream input and Grid output
             # as xesmf.backend.esmf_regrid_build filters the output mask in that case
             # (ESMF does not support output masks for LocStream input and Grid output)
+            # Only method supported is `nearest_s2d`:
+            #   For other methods the masking approach may lead to unexpected results
+            #   as the weights are applied post weight generation and other methods may have
+            #   the source-target mapping depending on the location of masked cells.
             if (
                 isinstance(grid_in, LocStream)
                 and isinstance(grid_out, Grid)
                 and grid_out.mask is not None
                 and grid_out.mask[0] is not None
+                and method == 'nearest_s2d'
             ):
                 self.weights = post_apply_target_mask_to_weights(self.weights, grid_out.mask[0])
 

--- a/xesmf/tests/test_smm.py
+++ b/xesmf/tests/test_smm.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 import sparse as sps
 import xarray as xr
 
@@ -27,3 +28,49 @@ def test_add_nans_to_weights():
 
     Matout = xe.smm.add_nans_to_weights(xr.DataArray(Matin, dims=('in', 'out')))
     assert np.allclose(Matin.todense(), Matout.data.todense())
+
+
+def test_post_apply_target_mask_to_weights():
+    # Create a small sparse weights matrix with shape (9 target, 4 source)
+    #  coords = [[target_indices], [source_indices]]
+    coords = np.array([[0, 1, 1, 2, 3, 3, 4, 5], [0, 0, 1, 1, 2, 3, 2, 3]])
+    data = np.array([0.1, 0.2, 0.3, 0.4, 0.5, 0.45, 0.7, 0.8])
+    shape = (6, 4)
+    W_sparse = sps.COO(coords, data, shape=shape)
+    weights = xr.DataArray(W_sparse, dims=('out_dim', 'in_dim'))
+
+    # Define a 3x3 mask for target (flattened size = 9):
+    #   If all goes to plan, weights of cells 3 and 4 (i.e. index 2 and 3)
+    #   will be set to 0.
+    target_mask_2d = np.array([[True, False], [True, True], [False, True]])
+
+    # Apply mask
+    masked_weights = xe.smm.post_apply_target_mask_to_weights(weights, target_mask_2d)
+
+    # Check results
+    np.testing.assert_array_equal(masked_weights.data.data, np.array([0.1, 0.2, 0.3, 0.7, 0.8]))
+    np.testing.assert_array_equal(
+        masked_weights.data.coords, np.array([[0, 1, 1, 4, 5], [0, 0, 1, 2, 3]])
+    )
+
+
+def test_post_apply_target_mask_to_weights_exceptions():
+    # Create a weights DataArray & mask
+    coords = np.array([[0, 1], [0, 1]])
+    data = np.array([0.5, 0.5])
+    shape = (2, 2)
+    W_sparse = sps.COO(coords, data, shape=shape)
+    weights = xr.DataArray(W_sparse, dims=('out_dim', 'in_dim'))
+    valid_mask = np.array([[True, False]])
+
+    # Mask not array-like
+    with pytest.raises(TypeError):
+        xe.smm.post_apply_target_mask_to_weights(weights, 'not_array_like')
+
+    # Shape mismatch
+    wrong_shape_mask = np.array([[True, False, True]])
+    with pytest.raises(ValueError):
+        xe.smm.post_apply_target_mask_to_weights(weights, wrong_shape_mask)
+
+    # That should work
+    xe.smm.post_apply_target_mask_to_weights(weights, valid_mask)


### PR DESCRIPTION
#### Enabling target masks for LocStream input
- For `LocStream` input or output, masks are generally filtered/ignored and not handed to ESMF, as ESMF apparently crashes in that case
- This PR adds the new function `xesmf.smm.post_apply_target_mask_to_weights` to zero out weights of masked target grid cells post weight generation
- The weights are automatically adjusted with above new function in  `BaseRegridder` in the case of all the following conditions being True:
  -  `LocStream` input
  -  `Grid` output
  - `grid_out` having a mask defined
  - method set to `nearest_s2d` (for `LocStream` input, the only other option would anyways only be `nearest_d2s`)
- This may lead to unexpected results when not using with `nearest_s2d`, which is why the automatic application is restricted to that method. To my understanding, as the masking is applied *post* weight generation, the resulting weights may differ from the "masking during the weights generation" if the mapping between `source <--> target` may be influenced by the location of masked cells. But this would be the case for `nearest_d2s`.

I set this up to allow making use of land-sea-masks when remapping from unstructured grids with the "trick" described in #115  - without land-sea-mask there was undesired extrapolation happening outside the source domain:  

#### Scatter plot of source grid cell locations (AWI-CM-1-1-MR FESOM unstructured ocean model grid)
<img width="700" alt="image" src="https://github.com/user-attachments/assets/df189da4-2b2a-4bf5-aae9-cfb3e77d27a2" />

#### Remapped result before - even when target mask was defined (`nearest_s2d`) 
<img width="400" alt="image" src="https://github.com/user-attachments/assets/9ead7dbf-c37d-4829-bbed-5b7db4c3a760" />

#### Remapped result after - with target mask defined (`nearest_s2d`) 
<img width="400" alt="image" src="https://github.com/user-attachments/assets/c701676d-e622-43c4-8a32-95325fd5b89a" />