### PR TITLE
Skip some tests when ESMF has no PIO support

### DIFF
--- a/xesmf/backend.py
+++ b/xesmf/backend.py
@@ -350,11 +350,9 @@ def esmf_regrid_build(  # noqa: C901
         - 'nearest_d2s'
 
     filename : str, optional
-        Offline weight file. **Require ESMPy 7.1.0.dev38 or newer.**
-        With the weights available, we can use Scipy's sparse matrix
-        multiplication to apply weights, which is faster and more Pythonic
-        than ESMPy's online regridding. If None, weights are stored in
-        memory only.
+        Save the weights to this netCDF file.
+        Require ESMPy 7.1.1 or newer and a parallel IO enabled ESMF.
+        Saving weights here is not needed for xESMF.
 
     extra_dims : a list of integers, optional
         Extra dimensions (e.g. time or levels) in the data field
@@ -533,7 +531,13 @@ def esmf_regrid_build(  # noqa: C901
     if vector_regrid:
         kwargs['vector_regrid'] = vector_regrid
 
-    regrid = ESMF.Regrid(sourcefield, destfield, **kwargs)
+    try:
+        regrid = ESMF.Regrid(sourcefield, destfield, **kwargs)
+    except ESMF.util.exceptions.PIOMissing as err:
+        raise ValueError(
+            'ESMF needs to be build with parallel-IO to be able to write weights to file. '
+            'You can either write the weights using xESMF instead or re-install ESMF.'
+        ) from err
 
     return regrid
 

--- a/xesmf/tests/test_backend.py
+++ b/xesmf/tests/test_backend.py
@@ -169,6 +169,7 @@ def test_esmf_extrapolation_creep_fill():
     esmf_regrid_finalize(regrid_creep_fill)
 
 
+@pytest.mark.skipif(not ESMF.api.constants._ESMF_PIO, reason='ESMF without parallel I/O')
 def test_regrid():
     # use conservative regridding as an example,
     # since it is the most well-tested studied one in papers
@@ -187,7 +188,7 @@ def test_regrid():
     add_corner(grid_in, lon_b_in.T, lat_b_in.T)
     add_corner(grid_out, lon_b_out.T, lat_b_out.T)
 
-    # also write to file for scipy regridding
+    # also write to file for regridding within xesmf
     filename = 'test_weights.nc'
     if os.path.exists(filename):
         os.remove(filename)
@@ -200,7 +201,7 @@ def test_regrid():
     rel_err = (data_out_esmpy - data_ref) / data_ref  # relative error
     assert np.max(np.abs(rel_err)) < 0.05
 
-    # apply regridding using scipy
+    # apply regridding using xesmf
     weights = read_weights(filename, lon_in.size, lon_out.size).data
     shape_in = lon_in.shape
     shape_out = lon_out.shape
@@ -212,7 +213,7 @@ def test_regrid():
 
     # finally, test broadcasting with scipy
     # TODO: need to test broadcasting with ESMPy backend?
-    # We only use Scipy in frontend, and ESMPy is just for backend benchmark
+    # We only use sparse matrices in frontend, and ESMPy is just for backend benchmark
     # However, it is useful to compare performance and show scipy is 3x faster
     data4D_out = apply_weights(w, data4D_in, shape_in, shape_out)
 
@@ -279,6 +280,7 @@ def test_esmf_locstream():
     esmf_regrid_build(ls, grid_in, 'nearest_s2d')
 
 
+@pytest.mark.skipif(not ESMF.api.constants._ESMF_PIO, reason='ESMF without parallel I/O')
 def test_read_weights(tmp_path):
     fn = tmp_path / 'weights.nc'
 

--- a/xesmf/tests/test_frontend.py
+++ b/xesmf/tests/test_frontend.py
@@ -13,6 +13,11 @@ from packaging.version import Version
 from shapely import segmentize
 from shapely.geometry import MultiPolygon, Polygon
 
+try:
+    import esmpy as ESMF
+except ImportError:
+    import ESMF
+
 import xesmf as xe
 from xesmf.frontend import as_2d_mesh
 
@@ -245,6 +250,7 @@ def test_regridder_w():
     assert averager.w.shape == (2,) + ds_in_cf.lat.shape + ds_in_cf.lon.shape
 
 
+@pytest.mark.skipif(not ESMF.api.constants._ESMF_PIO, reason='ESMF without parallel I/O')
 @pytest.mark.parametrize('unmapped_to_nan', [True, False])
 def test_to_netcdf(tmp_path, unmapped_to_nan):
     from xesmf.backend import Grid, esmf_regrid_build
@@ -840,11 +846,6 @@ def test_regrid_dataset_from_locstream():
 
 
 def test_ds_to_ESMFlocstream():
-    try:
-        import esmpy as ESMF
-    except ImportError:
-        import ESMF
-
     from xesmf.frontend import ds_to_ESMFlocstream
 
     locstream, shape, names = ds_to_ESMFlocstream(ds_locs)
@@ -945,11 +946,6 @@ def test_compare_weights_from_poly_and_grid():
 
 
 def test_polys_to_ESMFmesh():
-    try:
-        import esmpy as ESMF
-    except ImportError:
-        import ESMF
-
     from xesmf.frontend import polys_to_ESMFmesh
 
     # No overlap but multi + holes


### PR DESCRIPTION
For some reasons, some versions of python/conda/esmf solve to an environment without MPI, which seems to be required by ESMF to write the weights file. 

This is not an issue for xESMF, since we do our own weights file writing. However, there are a few tests that compare both. I skipped those tests when ESMF seems to be build without parallel I/O.

The issue happened on Python 3.12 / ESMF 8.6. Other pairs all had MPI in the resulting environment.

I also added a clearer error message.