### PR TITLE
Lazily enable sparse operation caching for fast repeated weight application

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,16 @@
 What's new
 ==========
 
+Unreleased
+----------
+* Repeated numpy-path applications no longer re-sort the sparse weights on
+  every call (``sparse``'s operation caching is enabled at first use);
+  results are bit-identical. Weights are now logically immutable while
+  attached — assign a replacement to ``regridder.weights`` instead of
+  mutating buffers. The cache is not pickled and re-enables lazily;
+  dask-only regridders are unaffected.
+  By `Ben Mares <https://github.com/maresb>`_.
+
 0.9.2 (2025-11-27)
 ------------------
 This release drops support for Python < 3.11. xESMF aims to preserve support for older python and ESMF version as long as possible with its reduced maintaining team. The most recent windows release of ESMF is currently 8.4.2 and new versions of xESMF will support it as long as it is not updated. All fixes in :pull:`463`, by `Pascal Bourgault <https://github.com/aulemahal>`_.

--- a/xesmf/frontend.py
+++ b/xesmf/frontend.py
@@ -627,6 +627,11 @@ class BaseRegridder(object):
               - or a path to a netCDF file created by ESMF.
             If None, compute the weights.
 
+            On first NumPy use, xESMF enables sparse operation caching on
+            the attached COO. Caller-supplied weights are not copied, so
+            treat attached weights as immutable; replace
+            ``regridder.weights`` rather than mutating COO buffers.
+
         ignore_degenerate : bool, optional
             If False (default), raise error if grids contain degenerated cells
             (i.e. triangles or lines, instead of quadrilaterals)
@@ -1028,7 +1033,11 @@ class BaseRegridder(object):
             weights = da.from_array(weights, chunks=(output_chunks + indata.chunksize[-2:]))
             outdata = self._regrid(indata, weights, **kwargs)
         else:  # numpy — keep weights 2D; apply_weights does flat contraction
-            outdata = self._regrid(indata, self.weights.data, **kwargs)
+            wdata = self.weights.data
+            if isinstance(wdata, sps.COO) and getattr(wdata, '_cache', None) is None:
+                # Cache sparse.tensordot's internal transpose and reshape.
+                wdata.enable_caching()
+            outdata = self._regrid(indata, wdata, **kwargs)
         return outdata
 
     def regrid_numpy(self, indata, **kwargs):

--- a/xesmf/tests/test_frontend.py
+++ b/xesmf/tests/test_frontend.py
@@ -5,10 +5,11 @@ import cf_xarray as cfxr
 import dask
 import numpy as np
 import pytest
+import sparse
 import xarray as xr
 from dask.array.core import PerformanceWarning
 from esmpy import __version__ as esmf_version
-from numpy.testing import assert_allclose, assert_almost_equal, assert_equal
+from numpy.testing import assert_allclose, assert_almost_equal, assert_array_equal, assert_equal
 from packaging.version import Version
 from shapely import segmentize
 from shapely.geometry import MultiPolygon, Polygon
@@ -1550,3 +1551,70 @@ def test_input_output_dims():
     # Check that the shapes match the output grid
     assert ds_result['y2'].shape == ds_out['y'].shape
     assert ds_result['x2'].shape == ds_out['x'].shape
+
+
+def test_weight_caching_bit_identical_and_repeatable():
+    regridder = xe.Regridder(ds_in, ds_out, 'conservative')
+    indata = ds_in['data4D'].values
+
+    first = regridder(indata)
+    second = regridder(indata)
+    assert_array_equal(first, second)
+
+    # Reference: an uncached evaluation of the same weight values.
+    coo = regridder.weights.data
+    fresh = sparse.COO(coo.coords.copy(), coo.data.copy(), shape=coo.shape)
+    reference = regridder._regrid(
+        indata,
+        fresh,
+        shape_in=regridder.shape_in,
+        shape_out=regridder.shape_out,
+        skipna=False,
+        na_thres=1.0,
+    )
+    assert_array_equal(first, reference)
+
+
+def test_weight_replacement_reenables_caching():
+    regridder = xe.Regridder(ds_in, ds_out, 'conservative')
+    indata = ds_in['data4D'].values
+    before = regridder(indata)
+
+    regridder.weights = regridder.weights * 0.5
+    assert getattr(regridder.weights.data, '_cache', None) is None
+    after = regridder(indata)
+    assert_array_equal(after, before * 0.5)
+    assert getattr(regridder.weights.data, '_cache', None) is not None
+
+
+def test_unpickled_regridder_reenables_caching():
+    import pickle
+
+    regridder = xe.Regridder(ds_in, ds_out, 'conservative')
+    indata = ds_in['data4D'].values
+    expected = regridder(indata)
+
+    restored = pickle.loads(pickle.dumps(regridder))
+    assert getattr(restored.weights.data, '_cache', None) is None
+    actual = restored(indata)
+    assert getattr(restored.weights.data, '_cache', None) is not None
+    assert_array_equal(actual, expected)
+
+
+def test_cached_weights_are_collectible():
+    import gc
+    import weakref
+
+    regridder = xe.Regridder(ds_in, ds_out, 'conservative')
+    regridder(ds_in['data4D'].values)
+    ref = weakref.ref(regridder.weights.data)
+    del regridder
+    gc.collect()
+    assert ref() is None
+
+
+def test_dask_path_does_not_populate_weight_cache():
+    regridder = xe.Regridder(ds_in, ds_out, 'conservative')
+    indata = dask.array.from_array(ds_in['data4D'].values, chunks=(2, 2, -1, -1))
+    regridder(indata).compute()
+    assert getattr(regridder.weights.data, '_cache', None) is None


### PR DESCRIPTION
> [!WARNING]
> **AI disclosure:** This PR was drafted in collaboration with Claude Fable and ChatGPT Sol, and has undergone several rounds of human and agentic feedback.

## Summary

After [pangeo-data/xESMF#476](https://github.com/pangeo-data/xESMF/pull/476) moved NumPy applications to 2-D weights, `sparse.tensordot` still transposes and re-sorts the COO coordinates on every call. This PR lazily enables [`COO.enable_caching()`](https://sparse.pydata.org/en/latest/api/COO/#sparse.COO.enable_caching) to reuse that work.

## Benchmark

```python
import time
import numpy as np
import xesmf as xe

ds_in = xe.util.grid_global(0.125, 0.125)  # 2880 x 1440
ds_out = xe.util.grid_global(0.5, 0.5)     # 720 x 360
regridder = xe.Regridder(ds_in, ds_out, "conservative")  # 5.2M-nnz weights
fields = np.random.default_rng(0).random((11, *ds_in["lon"].shape))

regridder(fields[0])  # first call
for field in fields[1:]:  # a fresh field each call, as in per-timestep use
    t0 = time.perf_counter(); regridder(field); print(time.perf_counter() - t0)
```

| | first call | repeat call (mean of 10) |
|---|---|---|
| master | 0.308 s | 0.125 s |
| this PR | 0.309 s | **0.005 s** |

~25x *for this configuration*; the gain scales with the per-call share of the weight re-sort, so it shrinks when many fields are batched into a single call. Results are bit-identical (tested, including against an uncached evaluation).

## Contract

Weights are logically immutable while attached (documented on the `weights` parameter): replace `regridder.weights` rather than mutating COO buffers. Caller-supplied weights are not copied, so mutation can also leave stale results through external references.

## Notes

- Caching is enabled lazily so Dask-only regridders do not retain a cached 4-D reshape; the Dask path is otherwise unchanged.
- The cache is not pickled (`sparse` omits it from `__getstate__`); restored regridders re-enable it on first use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
